### PR TITLE
fix: disable deployment controller routes

### DIFF
--- a/.github/actions/ansible-controller/action.yml
+++ b/.github/actions/ansible-controller/action.yml
@@ -17,6 +17,10 @@ inputs:
   host-key-fingerprint:
     description: Expected Docker ED25519 SSH host-key fingerprint
     required: true
+  accept-subnet-routes:
+    description: Keep the two approved subnet routes instead of disabling route acceptance before host contact
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -49,3 +53,4 @@ runs:
         "${{ github.action_path }}/../../scripts/prepare-ansible-controller.sh"
         "${{ inputs.target-ip }}"
         "${{ inputs.host-key-fingerprint }}"
+        "${{ inputs.accept-subnet-routes }}"

--- a/.github/scripts/prepare-ansible-controller.sh
+++ b/.github/scripts/prepare-ansible-controller.sh
@@ -3,47 +3,79 @@ set -euo pipefail
 
 target_ip=${1:?target Tailscale IP is required}
 expected_fingerprint=${2:?expected SSH fingerprint is required}
+accept_subnet_routes=${3:-false}
 
-sudo tailscale debug prefs | jq -e '
+case "$accept_subnet_routes" in
+  true)
+    expected_routes=192.168.0.100/32,192.168.0.123/32
+    ;;
+  false)
+    expected_routes=
+    sudo tailscale set --accept-routes=false
+    ;;
+  *)
+    echo "accept-subnet-routes must be true or false" >&2
+    exit 64
+    ;;
+esac
+
+sudo tailscale debug prefs | jq -e --argjson expected_routes "$accept_subnet_routes" '
   .CorpDNS == false and
   .RunSSH == false and
-  .RouteAll == true
+  .RouteAll == $expected_routes
 '
 
-route_file=$(mktemp)
+route_v4_file=$(mktemp)
+route_v6_file=$(mktemp)
 keyscan_file=$(mktemp)
-trap 'rm -f "$route_file" "$keyscan_file"' EXIT
-ip -j -4 route show table 52 >"$route_file"
+trap 'rm -f "$route_v4_file" "$route_v6_file" "$keyscan_file"' EXIT
+ip -j -4 route show table 52 >"$route_v4_file"
+ip -j -6 route show table 52 >"$route_v6_file"
 
-ROUTE_FILE="$route_file" python - <<'PY'
+EXPECTED_ROUTES="$expected_routes" \
+ROUTE_V4_FILE="$route_v4_file" \
+ROUTE_V6_FILE="$route_v6_file" \
+python - <<'PY'
 import ipaddress
 import json
 import os
 
 expected = {
-    (ipaddress.ip_network("192.168.0.100/32"), "tailscale0"),
-    (ipaddress.ip_network("192.168.0.123/32"), "tailscale0"),
+    (ipaddress.ip_network(route), "tailscale0")
+    for route in os.environ["EXPECTED_ROUTES"].split(",")
+    if route
 }
-tailnet = ipaddress.ip_network("100.64.0.0/10")
-
-with open(os.environ["ROUTE_FILE"], encoding="utf-8") as route_stream:
-    routes = json.load(route_stream)
+tailnets = {
+    4: ipaddress.ip_network("100.64.0.0/10"),
+    6: ipaddress.ip_network("fd7a:115c:a1e0::/48"),
+}
+route_sources = (
+    (os.environ["ROUTE_V4_FILE"], "0.0.0.0/0"),
+    (os.environ["ROUTE_V6_FILE"], "::/0"),
+)
 
 scoped_routes = set()
-for route in routes:
-    destination = route.get("dst", "0.0.0.0/0")
-    network = ipaddress.ip_network(destination, strict=False)
-    if not network.subnet_of(tailnet):
-        scoped_routes.add((network, route.get("dev")))
+for route_path, default_route in route_sources:
+    with open(route_path, encoding="utf-8") as route_stream:
+        routes = json.load(route_stream)
+
+    for route in routes:
+        destination = route.get("dst", default_route)
+        network = ipaddress.ip_network(destination, strict=False)
+        if not network.subnet_of(tailnets[network.version]):
+            scoped_routes.add((network, route.get("dev")))
 
 if scoped_routes != expected:
     raise SystemExit(
         f"unexpected non-tailnet routes in table 52: {sorted(map(str, scoped_routes))}"
     )
 
-print("Approved subnet routes:")
-for network, device in sorted(expected, key=lambda item: str(item[0])):
-    print(f"  {network} dev {device}")
+if expected:
+    print("Approved subnet routes:")
+    for network, device in sorted(expected, key=lambda item: str(item[0])):
+        print(f"  {network} dev {device}")
+else:
+    print("No non-tailnet IPv4 or IPv6 routes accepted.")
 PY
 
 for attempt in {1..10}; do

--- a/.github/workflows/ansible-deploy.yml
+++ b/.github/workflows/ansible-deploy.yml
@@ -60,6 +60,7 @@ jobs:
           tags: tag:ci-plan
           target-ip: 100.111.210.72
           host-key-fingerprint: SHA256:2wHl3xsBkNYprqP99usjZdwj2Rytcc+MtJVErhowVYw
+          accept-subnet-routes: "false"
 
       - name: Validate inventory, connectivity, and playbook syntax
         working-directory: ansible
@@ -150,6 +151,7 @@ jobs:
           tags: tag:ci-apply
           target-ip: 100.111.210.72
           host-key-fingerprint: SHA256:2wHl3xsBkNYprqP99usjZdwj2Rytcc+MtJVErhowVYw
+          accept-subnet-routes: "false"
 
       - name: Validate inventory, connectivity, and playbook syntax
         working-directory: ansible

--- a/.github/workflows/ansible-plan.yml
+++ b/.github/workflows/ansible-plan.yml
@@ -37,6 +37,7 @@ jobs:
           tags: tag:ci
           target-ip: 100.111.210.72
           host-key-fingerprint: SHA256:2wHl3xsBkNYprqP99usjZdwj2Rytcc+MtJVErhowVYw
+          accept-subnet-routes: "true"
 
       - name: Validate the production inventory and audit syntax
         working-directory: ansible

--- a/.github/workflows/plan-controller-bootstrap.yml
+++ b/.github/workflows/plan-controller-bootstrap.yml
@@ -45,6 +45,7 @@ jobs:
           tags: tag:ci-apply
           target-ip: 100.111.210.72
           host-key-fingerprint: SHA256:2wHl3xsBkNYprqP99usjZdwj2Rytcc+MtJVErhowVYw
+          accept-subnet-routes: "false"
 
       - name: Validate and check the bootstrap
         id: check
@@ -107,6 +108,7 @@ jobs:
           tags: tag:ci-apply
           target-ip: 100.111.210.72
           host-key-fingerprint: SHA256:2wHl3xsBkNYprqP99usjZdwj2Rytcc+MtJVErhowVYw
+          accept-subnet-routes: "false"
 
       - name: Revalidate the checked bootstrap plan
         working-directory: ansible

--- a/docs/github-actions-deploy.md
+++ b/docs/github-actions-deploy.md
@@ -2,9 +2,9 @@
 
 ## Current status
 
-[`.github/workflows/ansible-deploy.yml`](../.github/workflows/ansible-deploy.yml) stages an automatic, single-tag
-plan-to-apply pipeline on a feature branch. Neither automatic production plans nor production applies are active yet.
-No normal Ansible run is authorized.
+[`.github/workflows/ansible-deploy.yml`](../.github/workflows/ansible-deploy.yml) is merged but stages an inactive automatic,
+single-tag plan-to-apply pipeline. Neither automatic production plans nor production applies are enabled. No normal
+Ansible run is authorized.
 
 Both repository activation variables are deliberately set to `false`:
 
@@ -15,6 +15,12 @@ ANSIBLE_APPLY_ENABLED=false
 
 The plan and apply jobs check these variables before targeting their environments. No automatic remote plan, deployment
 approval request, or normal Ansible run can start while the corresponding gate is disabled.
+
+The first protected bootstrap check ([`30676568592`](https://github.com/soodoh/docker-compose/actions/runs/30676568592))
+proved the `infrastructure-apply` OIDC exchange and ephemeral `tag:ci-apply` enrollment, then stopped before ping, SSH,
+or Ansible because the shared route assertion saw only `192.168.0.123/32`. Cleanup succeeded. Deployment controllers
+now disable accepted subnet routes immediately after enrollment and require zero non-tailnet IPv4 or IPv6 routes before host contact;
+the manual audit retains its separately approved two-route behavior.
 
 ## Separate trust paths
 
@@ -73,7 +79,7 @@ The plan job uses `infrastructure-auto-plan`, its exact GitHub OIDC subject, `ta
 2. Validates the single reviewed intent tag.
 3. Installs pinned Python 3.13.14 and `ansible-core==2.21.2`.
 4. Creates an ephemeral `tag:ci-plan` Tailscale node without reusable credentials.
-5. Verifies DNS and Tailscale SSH are disabled and only the two approved `/32` subnet routes are installed.
+5. Disables accepted subnet routes, tailnet DNS, and Tailscale SSH before host contact, then requires no non-tailnet IPv4 or IPv6 routes.
 6. Requires the recorded Docker ED25519 host-key fingerprint.
 7. Connects only as unprivileged `ansible-plan` and validates inventory, connectivity, and `site.yml` syntax.
 8. Runs `site.yml --check --diff` for the selected tag.


### PR DESCRIPTION
## Summary

- retain the manual audit's exact two approved subnet routes
- immediately disable route acceptance for `tag:ci-plan` and `tag:ci-apply` before host contact
- fail closed on any non-tailnet IPv4 or IPv6 route
- record failed check run 30676568592

## Failure safety

Run 30676568592 successfully exchanged OIDC and joined as `tag:ci-apply`, then stopped at route verification before ping, SSH, or Ansible. Cleanup succeeded and no host mutation occurred.

## Validation

- `actionlint` v1.7.12
- `bash -n`
- dual-stack route fixtures
- `git diff --check`
- independent review: no blocker/high findings
