### PR TITLE
feat: stage deterministic compose artifacts

### DIFF
--- a/.github/workflows/compose-artifact.yml
+++ b/.github/workflows/compose-artifact.yml
@@ -1,0 +1,81 @@
+name: Validate deterministic Compose artifact
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/compose-artifact.yml
+      - .sops.yaml
+      - docker-compose.yml
+      - scripts/check-sops-env.py
+      - scripts/compose-artifact.py
+      - scripts/restore-dotenv-layout.py
+      - secrets/**
+      - services/*.yml
+      - services/data/**
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/compose-artifact.yml
+      - .sops.yaml
+      - docker-compose.yml
+      - scripts/check-sops-env.py
+      - scripts/compose-artifact.py
+      - scripts/restore-dotenv-layout.py
+      - secrets/**
+      - services/*.yml
+      - services/data/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Hash and copy exact Compose artifact
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out the exact candidate commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Prove deterministic artifact selection and copy
+        id: artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          desired_hash=$(python3 scripts/compose-artifact.py hash)
+          repeated_hash=$(python3 scripts/compose-artifact.py hash)
+          [[ $desired_hash == "$repeated_hash" ]]
+
+          artifact_root="$RUNNER_TEMP/compose-artifact"
+          copied_hash=$(python3 scripts/compose-artifact.py copy "$artifact_root")
+          [[ $copied_hash == "$desired_hash" ]]
+          staged_hash=$(python3 "$artifact_root/scripts/compose-artifact.py" \
+            --root "$artifact_root" --no-git hash)
+          [[ $staged_hash == "$desired_hash" ]]
+
+          file_count=$(python3 scripts/compose-artifact.py list | wc -l)
+          echo "hash=$desired_hash" >>"$GITHUB_OUTPUT"
+          echo "files=$file_count" >>"$GITHUB_OUTPUT"
+
+      - name: Summarize artifact identity
+        shell: bash
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+          ARTIFACT_FILES: ${{ steps.artifact.outputs.files }}
+        run: |
+          {
+            echo "### Deterministic Compose artifact"
+            echo
+            echo "- Commit: \`$GITHUB_SHA\`"
+            echo "- Files: \`$ARTIFACT_FILES\`"
+            echo "- SHA-256: \`$ARTIFACT_HASH\`"
+            echo
+            echo "The artifact excludes Git metadata, documentation, worktrees, plaintext environment files, and unrelated repository files."
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/compose-stage.yml
+++ b/.github/workflows/compose-stage.yml
@@ -1,0 +1,165 @@
+name: Stage exact Compose artifact
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ansible-production
+  cancel-in-progress: false
+
+env:
+  ANSIBLE_HOST_KEY_CHECKING: "true"
+  ANSIBLE_NOCOLOR: "1"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+jobs:
+  stage:
+    name: Stage without Compose convergence
+    if: vars.ANSIBLE_APPLY_ENABLED == 'true' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: infrastructure-apply
+
+    steps:
+      - name: Check out the exact main commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Build and identify the exact controller artifact
+        id: artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_root="$RUNNER_TEMP/compose-artifact"
+          desired_hash=$(python3 scripts/compose-artifact.py hash)
+          copied_hash=$(python3 scripts/compose-artifact.py copy "$artifact_root")
+          [[ $copied_hash == "$desired_hash" ]]
+          [[ $(python3 "$artifact_root/scripts/compose-artifact.py" \
+            --root "$artifact_root" --no-git hash) == "$desired_hash" ]]
+          echo "root=$artifact_root" >>"$GITHUB_OUTPUT"
+          echo "hash=$desired_hash" >>"$GITHUB_OUTPUT"
+
+      - name: Prepare the restricted apply controller
+        uses: ./.github/actions/ansible-controller
+        with:
+          oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TS_AUDIENCE }}
+          tags: tag:ci-apply
+          target-ip: 100.111.210.72
+          host-key-fingerprint: SHA256:2wHl3xsBkNYprqP99usjZdwj2Rytcc+MtJVErhowVYw
+          accept-subnet-routes: "false"
+
+      - name: Validate inventory, connectivity, and staging syntax
+        working-directory: ansible
+        shell: bash
+        run: |
+          set -euo pipefail
+          ansible-inventory -i inventory/production.yml --graph
+          ansible-playbook -i inventory/production.yml --syntax-check playbooks/stage-compose.yml
+          ansible -i inventory/production.yml docker_host -m ansible.builtin.ping
+
+      - name: Review the staging check-mode difference
+        id: plan
+        working-directory: ansible
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+          ARTIFACT_ROOT: ${{ steps.artifact.outputs.root }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          plan_log="$RUNNER_TEMP/compose-stage-plan.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/stage-compose.yml --check --diff \
+            -e "compose_artifact_hash=$ARTIFACT_HASH" \
+            -e "compose_artifact_controller_dir=$ARTIFACT_ROOT" | tee "$plan_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$plan_log" docker-host-production)
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Stage, decrypt, validate, and dry-run the reviewed artifact
+        id: apply
+        working-directory: ansible
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+          ARTIFACT_ROOT: ${{ steps.artifact.outputs.root }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          apply_log="$RUNNER_TEMP/compose-stage-apply.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/stage-compose.yml \
+            -e "compose_artifact_hash=$ARTIFACT_HASH" \
+            -e "compose_artifact_controller_dir=$ARTIFACT_ROOT" \
+            -e compose_stage_confirmed=true | tee "$apply_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$apply_log" docker-host-production)
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Require zero staging changes after execution
+        id: postcheck
+        working-directory: ansible
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+          ARTIFACT_ROOT: ${{ steps.artifact.outputs.root }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          postcheck_log="$RUNNER_TEMP/compose-stage-postcheck.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/stage-compose.yml --check --diff \
+            -e "compose_artifact_hash=$ARTIFACT_HASH" \
+            -e "compose_artifact_controller_dir=$ARTIFACT_ROOT" | tee "$postcheck_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$postcheck_log" docker-host-production)
+          [[ $(jq -r '.changed' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Run the complete read-only audit
+        id: audit
+        working-directory: ansible
+        shell: bash
+        run: |
+          set -euo pipefail
+          audit_log="$RUNNER_TEMP/compose-stage-audit.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/audit.yml --check --diff | tee "$audit_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$audit_log" docker-host-production)
+          [[ $(jq -r '.changed' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Summarize secret-free staging evidence
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+          PLAN_RECAP: ${{ steps.plan.outputs.recap }}
+          APPLY_RECAP: ${{ steps.apply.outputs.recap }}
+          POSTCHECK_RECAP: ${{ steps.postcheck.outputs.recap }}
+          AUDIT_RECAP: ${{ steps.audit.outputs.recap }}
+        shell: bash
+        run: |
+          {
+            echo "### Compose artifact staging"
+            echo
+            echo "- Commit: \`$GITHUB_SHA\`"
+            echo "- Artifact SHA-256: \`$ARTIFACT_HASH\`"
+            echo "- Check-mode recap: \`$PLAN_RECAP\`"
+            echo "- Staging recap: \`$APPLY_RECAP\`"
+            echo "- Zero-change post-check: \`$POSTCHECK_RECAP\`"
+            echo "- Full audit: \`$AUDIT_RECAP\`"
+            echo
+            echo "No Compose pull, build, create, up, restart, removal, orphan removal, or volume operation was authorized."
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/ansible/group_vars/docker_host.yml
+++ b/ansible/group_vars/docker_host.yml
@@ -45,6 +45,17 @@ age_archive_sha256: bdc69c09cbdd6cf8b1f333d372a1f58247b3a33146406333e30c0f26e8f5
 age_binary_sha256: 2e305637f2a0555305e21c17fb74446acbb39b53135d43d4b744e50c287133a5
 age_keygen_binary_sha256: c56ef69834e18ca4d3b953117f4481522c35fb6862a5d2871685aa4685893664
 
+compose_project_name: docker-compose
+compose_deployment_root: /srv/docker-compose
+compose_current_dir: /srv/docker-compose/current
+compose_staging_root: /srv/docker-compose/staging
+compose_previous_dir: /srv/docker-compose/previous
+compose_runtime_env_path: /etc/docker-compose/production.env
+compose_age_identity_path: /etc/sops/age/keys.txt
+compose_deployed_hash_path: /var/lib/docker-compose/deployed.sha256
+compose_staged_inventory_path: /var/lib/docker-compose/staged-model.json
+compose_runtime_inventory_path: /var/lib/docker-compose/runtime-model.json
+
 audit_expected_declared_volume_count: 30
 audit_expected_compose_project_volume_count: 33
 

--- a/ansible/playbooks/stage-compose.yml
+++ b/ansible/playbooks/stage-compose.yml
@@ -1,0 +1,9 @@
+---
+- name: Stage and validate an exact Compose artifact without runtime convergence
+  hosts: docker_host
+  gather_facts: false
+  any_errors_fatal: true
+  vars_files:
+    - "{{ playbook_dir }}/../group_vars/docker_host.yml"
+  roles:
+    - role: compose_stage

--- a/ansible/roles/compose_stage/tasks/main.yml
+++ b/ansible/roles/compose_stage/tasks/main.yml
@@ -1,0 +1,313 @@
+---
+- name: Validate the Compose staging contract
+  ansible.builtin.assert:
+    that:
+      - compose_artifact_hash is match('^[0-9a-f]{64}$')
+      - compose_artifact_controller_dir | length > 0
+      - ansible_check_mode or (compose_stage_confirmed | default(false) | ansible.builtin.bool)
+    fail_msg: >-
+      Compose staging requires a 64-character artifact hash, an exact controller artifact directory,
+      and compose_stage_confirmed=true outside check mode.
+
+- name: Recompute the controller artifact hash
+  ansible.builtin.command:
+    argv:
+      - python
+      - "{{ compose_artifact_controller_dir }}/scripts/compose-artifact.py"
+      - --root
+      - "{{ compose_artifact_controller_dir }}"
+      - --no-git
+      - hash
+  delegate_to: localhost
+  become: false
+  register: compose_stage_controller_hash
+  changed_when: false
+
+- name: Require the reviewed controller artifact hash
+  ansible.builtin.assert:
+    that:
+      - compose_stage_controller_hash.stdout == compose_artifact_hash
+    fail_msg: "Controller artifact hash differs from the reviewed hash."
+
+- name: Inspect the final staging and runtime environment paths
+  ansible.builtin.stat:
+    path: "{{ item }}"
+    get_checksum: false
+    get_mime: false
+  become: true
+  register: compose_stage_existing_paths
+  loop:
+    - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
+    - "{{ compose_runtime_env_path }}"
+
+- name: Report the expected staging changes in check mode
+  ansible.builtin.debug:
+    msg: >-
+      Artifact {{ compose_artifact_hash }} will be installed under the root-owned staging tree and
+      the SOPS environment will be decrypted to the root-only runtime path.
+  changed_when: >-
+    not compose_stage_existing_paths.results[0].stat.exists or
+    not compose_stage_existing_paths.results[1].stat.exists
+  when: ansible_check_mode
+
+- name: Stage and validate the exact Compose artifact
+  when: not ansible_check_mode
+  block:
+    - name: Create stable Compose deployment directories
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "{{ item.mode }}"
+      become: true
+      loop:
+        - path: "{{ compose_deployment_root }}"
+          mode: "0755"
+        - path: "{{ compose_current_dir }}"
+          mode: "0755"
+        - path: "{{ compose_staging_root }}"
+          mode: "0755"
+        - path: "{{ compose_previous_dir }}"
+          mode: "0755"
+        - path: /etc/docker-compose
+          mode: "0700"
+        - path: /var/lib/docker-compose
+          mode: "0700"
+
+    - name: Create an incoming root-owned artifact directory
+      ansible.builtin.tempfile:
+        state: directory
+        path: "{{ compose_staging_root }}"
+        prefix: .incoming-
+      become: true
+      register: compose_stage_incoming
+      when: not compose_stage_existing_paths.results[0].stat.exists
+
+    - name: Copy only the deterministic artifact from the controller checkout
+      ansible.builtin.copy:
+        src: "{{ compose_artifact_controller_dir }}/"
+        dest: "{{ compose_stage_incoming.path }}/"
+        owner: root
+        group: root
+        mode: preserve
+        directory_mode: "0755"
+      become: true
+      when: not compose_stage_existing_paths.results[0].stat.exists
+
+    - name: Recompute the incoming host artifact hash
+      ansible.builtin.command:
+        argv:
+          - python
+          - "{{ compose_stage_incoming.path }}/scripts/compose-artifact.py"
+          - --root
+          - "{{ compose_stage_incoming.path }}"
+          - --no-git
+          - hash
+      become: true
+      register: compose_stage_incoming_hash
+      changed_when: false
+      when: not compose_stage_existing_paths.results[0].stat.exists
+
+    - name: Require the incoming host artifact hash
+      ansible.builtin.assert:
+        that:
+          - compose_stage_incoming_hash.stdout == compose_artifact_hash
+        fail_msg: "Incoming host artifact hash differs from the reviewed hash."
+      when: not compose_stage_existing_paths.results[0].stat.exists
+
+    - name: Atomically publish the immutable staging directory
+      ansible.builtin.command:
+        argv:
+          - /usr/bin/mv
+          - --
+          - "{{ compose_stage_incoming.path }}"
+          - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
+      become: true
+      when: not compose_stage_existing_paths.results[0].stat.exists
+
+    - name: Recompute the published host artifact hash
+      ansible.builtin.command:
+        argv:
+          - python
+          - "{{ compose_staging_root }}/{{ compose_artifact_hash }}/scripts/compose-artifact.py"
+          - --root
+          - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
+          - --no-git
+          - hash
+      become: true
+      register: compose_stage_host_hash
+      changed_when: false
+
+    - name: Require the published host artifact hash
+      ansible.builtin.assert:
+        that:
+          - compose_stage_host_hash.stdout == compose_artifact_hash
+        fail_msg: "Published host artifact hash differs from the reviewed hash."
+
+    - name: Create a root-only decryption workspace
+      ansible.builtin.tempfile:
+        state: directory
+        path: /etc/docker-compose
+        prefix: .decrypt-
+      become: true
+      register: compose_stage_decrypt_workspace
+      no_log: true
+
+    - name: Decrypt the canonical production environment in the root-only workspace
+      ansible.builtin.command:
+        argv:
+          - /usr/local/bin/sops
+          - decrypt
+          - --input-type
+          - dotenv
+          - --output-type
+          - dotenv
+          - --output
+          - "{{ compose_stage_decrypt_workspace.path }}/canonical.env"
+          - "{{ compose_staging_root }}/{{ compose_artifact_hash }}/secrets/production.sops.env"
+      environment:
+        SOPS_AGE_KEY_FILE: "{{ compose_age_identity_path }}"
+      become: true
+      no_log: true
+
+    - name: Restore the exact non-secret dotenv layout
+      ansible.builtin.command:
+        argv:
+          - python
+          - "{{ compose_staging_root }}/{{ compose_artifact_hash }}/scripts/restore-dotenv-layout.py"
+          - "{{ compose_stage_decrypt_workspace.path }}/canonical.env"
+          - "{{ compose_staging_root }}/{{ compose_artifact_hash }}/secrets/production.env.layout.json"
+          - "{{ compose_stage_decrypt_workspace.path }}/production.env"
+      become: true
+      no_log: true
+
+    - name: Atomically install the root-only runtime environment
+      ansible.builtin.copy:
+        src: "{{ compose_stage_decrypt_workspace.path }}/production.env"
+        dest: "{{ compose_runtime_env_path }}"
+        remote_src: true
+        owner: root
+        group: root
+        mode: "0600"
+      become: true
+      diff: false
+      no_log: true
+
+    - name: Validate staged Compose without displaying the resolved model
+      ansible.builtin.command:
+        argv:
+          - /usr/bin/docker
+          - compose
+          - --project-name
+          - "{{ compose_project_name }}"
+          - --project-directory
+          - "{{ compose_current_dir }}"
+          - --env-file
+          - "{{ compose_runtime_env_path }}"
+          - --file
+          - "{{ compose_staging_root }}/{{ compose_artifact_hash }}/docker-compose.yml"
+          - config
+          - --quiet
+      become: true
+      changed_when: false
+      no_log: true
+
+    - name: Produce the secret-free staged model inventory
+      ansible.builtin.command:
+        argv:
+          - python
+          - "{{ compose_staging_root }}/{{ compose_artifact_hash }}/scripts/compose-model-inventory.py"
+          - desired
+          - --artifact-root
+          - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
+          - --project-directory
+          - "{{ compose_current_dir }}"
+          - --env-file
+          - "{{ compose_runtime_env_path }}"
+          - --project-name
+          - "{{ compose_project_name }}"
+          - --output
+          - "{{ compose_stage_decrypt_workspace.path }}/staged-model.json"
+      become: true
+      changed_when: false
+      no_log: true
+
+    - name: Produce the secret-free runtime model inventory
+      ansible.builtin.command:
+        argv:
+          - python
+          - "{{ compose_staging_root }}/{{ compose_artifact_hash }}/scripts/compose-model-inventory.py"
+          - runtime
+          - --project-name
+          - "{{ compose_project_name }}"
+          - --output
+          - "{{ compose_stage_decrypt_workspace.path }}/runtime-model.json"
+      become: true
+      changed_when: false
+      no_log: true
+
+    - name: Install the secret-free model inventories
+      ansible.builtin.copy:
+        src: "{{ item.source }}"
+        dest: "{{ item.destination }}"
+        remote_src: true
+        owner: root
+        group: root
+        mode: "0600"
+      become: true
+      loop:
+        - source: "{{ compose_stage_decrypt_workspace.path }}/staged-model.json"
+          destination: "{{ compose_staged_inventory_path }}"
+        - source: "{{ compose_stage_decrypt_workspace.path }}/runtime-model.json"
+          destination: "{{ compose_runtime_inventory_path }}"
+
+    - name: Simulate Compose create without pulls, builds, removal, or mutation
+      ansible.builtin.command:
+        argv:
+          - /usr/bin/docker
+          - compose
+          - --dry-run
+          - --project-name
+          - "{{ compose_project_name }}"
+          - --project-directory
+          - "{{ compose_current_dir }}"
+          - --env-file
+          - "{{ compose_runtime_env_path }}"
+          - --file
+          - "{{ compose_staging_root }}/{{ compose_artifact_hash }}/docker-compose.yml"
+          - create
+          - --no-build
+          - --pull
+          - never
+      become: true
+      register: compose_stage_dry_run
+      changed_when: false
+      no_log: true
+
+    - name: Report the reviewed dry-run identity without model data
+      ansible.builtin.debug:
+        msg:
+          artifact_hash: "{{ compose_artifact_hash }}"
+          dry_run_sha256: "{{ compose_stage_dry_run.stdout | hash('sha256') }}"
+          dry_run_lines: "{{ compose_stage_dry_run.stdout_lines | length }}"
+
+  always:
+    - name: Remove any remaining incoming staging workspace
+      ansible.builtin.file:
+        path: "{{ compose_stage_incoming.path | default('/nonexistent') }}"
+        state: absent
+      become: true
+      when:
+        - not ansible_check_mode
+        - compose_stage_incoming is defined
+
+    - name: Remove the root-only decryption workspace
+      ansible.builtin.file:
+        path: "{{ compose_stage_decrypt_workspace.path | default('/nonexistent') }}"
+        state: absent
+      become: true
+      no_log: true
+      when:
+        - not ansible_check_mode
+        - compose_stage_decrypt_workspace is defined

--- a/docs/compose-deployment.md
+++ b/docs/compose-deployment.md
@@ -1,0 +1,70 @@
+# Repository-driven Compose deployment
+
+## Phase 3 staging design
+
+The deployment artifact is selected by `scripts/compose-artifact.py` from the exact Git checkout. It includes only:
+
+- `docker-compose.yml`;
+- the eight `services/*.yml` stack files;
+- tracked `services/data/**` files;
+- `.sops.yaml` and the encrypted production environment manifests; and
+- the deployment-only validation and layout helpers required on the host.
+
+Git metadata, documentation, worktrees, plaintext environment files, recovery keys, and unrelated repository files are excluded. A plaintext `*.env` path or private-key candidate inside the selection is a hard failure.
+
+The canonical artifact hash is SHA-256 over a version marker followed by each sorted UTF-8 filename and its raw bytes, both length-delimited. File timestamps, checkout paths, archive metadata, and runner-specific state do not affect the hash. CI proves that the source, copied artifact, and no-Git staged tree produce the same hash.
+
+## Stable host paths
+
+```text
+/srv/docker-compose/current
+/srv/docker-compose/staging/<artifact-sha256>
+/srv/docker-compose/previous
+/etc/docker-compose/production.env
+/var/lib/docker-compose/deployed.sha256
+```
+
+`current` is the only future live project directory. Staging directories are immutable and hash-addressed. A GitHub Actions checkout is only a controller source; no live bind mount may reference it.
+
+The existing `/home/docker/Projects/docker-compose` checkout and `.env` remain untouched rollback inputs until rollback confidence is documented.
+
+## Staging workflow
+
+`.github/workflows/compose-stage.yml` is manual, main-only, serialized with other production Ansible work, and uses the existing environment-bound `tag:ci-apply` identity. It:
+
+1. checks out the exact `main` commit;
+2. computes and copies the deterministic artifact on the controller;
+3. reviews `stage-compose.yml --check --diff`;
+4. copies only that artifact into a root-owned incoming host directory;
+5. recomputes the hash before atomically publishing `staging/<hash>`;
+6. decrypts SOPS only on the host through `/etc/sops/age/keys.txt`;
+7. restores the non-secret dotenv layout in a root-only temporary directory;
+8. atomically installs `/etc/docker-compose/production.env` as `root:root 0600` with `no_log: true`;
+9. validates with explicit project name, project directory, environment file, and `docker compose config --quiet`;
+10. writes root-owned secret-free desired and runtime inventories;
+11. runs `docker compose --dry-run create --no-build --pull never`; and
+12. requires a zero-change staging post-check and complete read-only audit.
+
+This workflow does not run Compose pull, build, create, up, restart, removal, orphan removal, or volume operations. The normal staging execution is separately confirmation-gated even after entering the protected apply environment.
+
+## Secret-free model evidence
+
+`scripts/compose-model-inventory.py` captures resolved Compose JSON and Docker inspection data only in process memory, then emits a restricted model containing:
+
+- project name and service/volume counts;
+- image references and current image IDs;
+- published ports;
+- bind and named-volume sources and targets;
+- devices;
+- network modes and network names; and
+- SHA-256 identities of health-check definitions.
+
+It never emits environment values, resolved commands, labels, or the complete Compose model. The desired inventory resolves relative bind sources against `/srv/docker-compose/current`, not a temporary staging or GitHub checkout.
+
+## Backup environment mount
+
+The backup services now declare `/etc/docker-compose/production.env:/backup/.env:ro`. Existing containers continue using the old bind until the separately controlled cutover; no staging operation recreates them.
+
+## Cutover boundary
+
+Phase 3 may populate staging, the empty stable directories, and the inactive root-only environment file. It must not synchronize an artifact into `current`, change runtime Compose labels, pull images, or converge containers. Those actions remain Phase 4 maintenance-window work.

--- a/scripts/compose-artifact.py
+++ b/scripts/compose-artifact.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Build and hash the deterministic Docker Compose deployment artifact."""
+
+from argparse import ArgumentParser, Namespace
+import hashlib
+import os
+from pathlib import Path, PurePosixPath
+import shutil
+import stat
+import subprocess
+import sys
+
+FORMAT_MARKER = b"docker-compose-artifact-v1\0"
+EXPLICIT_PATHS = {
+    ".sops.yaml",
+    "docker-compose.yml",
+    "scripts/check-sops-env.py",
+    "scripts/compose-artifact.py",
+    "scripts/compose-model-inventory.py",
+    "scripts/restore-dotenv-layout.py",
+    "secrets/production.env.keys",
+    "secrets/production.env.layout.json",
+    "secrets/production.sops.env",
+}
+
+
+def is_selected(path: str) -> bool:
+    candidate = PurePosixPath(path)
+    if path in EXPLICIT_PATHS:
+        return True
+    if len(candidate.parts) == 2 and candidate.parts[0] == "services":
+        return candidate.suffix == ".yml"
+    return len(candidate.parts) >= 3 and candidate.parts[:2] == ("services", "data")
+
+
+def reject_unsafe_path(path: str) -> None:
+    candidate = PurePosixPath(path)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise SystemExit("artifact contains an unsafe path")
+    if path.endswith(".env") and path != "secrets/production.sops.env":
+        raise SystemExit("artifact selection includes a plaintext environment path")
+    lowered = path.lower()
+    if any(token in lowered for token in ("private-key", "secret-key", "keys.txt")):
+        raise SystemExit("artifact selection includes a private-key candidate")
+
+
+def git_paths(root: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    return [os.fsdecode(path) for path in result.stdout.split(b"\0") if path]
+
+
+def filesystem_paths(root: Path) -> list[str]:
+    return [
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*")
+        if path.is_file() or path.is_symlink()
+    ]
+
+
+def selected_paths(root: Path, require_git_tracked: bool) -> list[str]:
+    candidates = git_paths(root) if require_git_tracked else filesystem_paths(root)
+    selected = sorted(path for path in candidates if is_selected(path))
+    if not selected:
+        raise SystemExit("artifact selection is empty")
+    if not EXPLICIT_PATHS.issubset(selected):
+        raise SystemExit("artifact is missing a required explicit path")
+    for path in selected:
+        reject_unsafe_path(path)
+        source = root / path
+        if not source.exists() and not source.is_symlink():
+            raise SystemExit("artifact contains a missing path")
+    return selected
+
+
+def path_bytes(root: Path, relative_path: str) -> bytes:
+    path = root / relative_path
+    if path.is_symlink():
+        return os.readlink(path).encode()
+    return path.read_bytes()
+
+
+def artifact_hash(root: Path, paths: list[str]) -> str:
+    digest = hashlib.sha256(FORMAT_MARKER)
+    for relative_path in paths:
+        encoded_path = relative_path.encode()
+        content = path_bytes(root, relative_path)
+        digest.update(len(encoded_path).to_bytes(8, "big"))
+        digest.update(encoded_path)
+        digest.update(len(content).to_bytes(8, "big"))
+        digest.update(content)
+    return digest.hexdigest()
+
+
+def copy_artifact(root: Path, destination: Path, paths: list[str]) -> None:
+    if destination.exists() and any(destination.iterdir()):
+        raise SystemExit("artifact destination must be absent or empty")
+    destination.mkdir(parents=True, exist_ok=True)
+    for relative_path in paths:
+        source = root / relative_path
+        target = destination / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_symlink():
+            target.symlink_to(os.readlink(source))
+            continue
+        shutil.copyfile(source, target)
+        source_mode = stat.S_IMODE(source.stat().st_mode)
+        target.chmod(source_mode)
+
+
+def parse_args() -> Namespace:
+    parser = ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--no-git", action="store_true")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    list_parser = subparsers.add_parser("list")
+    list_parser.add_argument("--null", action="store_true")
+    subparsers.add_parser("hash")
+    copy_parser = subparsers.add_parser("copy")
+    copy_parser.add_argument("destination", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    root = args.root.resolve()
+    paths = selected_paths(root, require_git_tracked=not args.no_git)
+
+    if args.command == "list":
+        separator = "\0" if args.null else "\n"
+        sys.stdout.write(separator.join(paths) + separator)
+        return
+    if args.command == "hash":
+        print(artifact_hash(root, paths))
+        return
+    if args.command == "copy":
+        destination = args.destination.resolve()
+        copy_artifact(root, destination, paths)
+        copied_paths = selected_paths(destination, require_git_tracked=False)
+        if copied_paths != paths:
+            raise SystemExit("copied artifact path set differs from the source")
+        source_hash = artifact_hash(root, paths)
+        if artifact_hash(destination, copied_paths) != source_hash:
+            raise SystemExit("copied artifact hash differs from the source")
+        print(source_hash)
+        return
+    raise SystemExit("unsupported artifact command")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compose-model-inventory.py
+++ b/scripts/compose-model-inventory.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Emit a secret-free desired or running Docker Compose model inventory."""
+
+from argparse import ArgumentParser, Namespace
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+from typing import Any
+
+
+def stable_hash(value: object) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def run_json(command: list[str]) -> Any:
+    result = subprocess.run(
+        command,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def desired_inventory(args: Namespace) -> dict[str, object]:
+    artifact_root = args.artifact_root.resolve()
+    model = run_json(
+        [
+            "/usr/bin/docker",
+            "compose",
+            "--project-name",
+            args.project_name,
+            "--project-directory",
+            str(args.project_directory.resolve()),
+            "--env-file",
+            str(args.env_file.resolve()),
+            "--file",
+            str(artifact_root / "docker-compose.yml"),
+            "config",
+            "--format",
+            "json",
+        ]
+    )
+
+    services = {}
+    for service_name, service in sorted(model.get("services", {}).items()):
+        mounts = service.get("volumes") or []
+        healthcheck = service.get("healthcheck")
+        services[service_name] = {
+            "image": service.get("image"),
+            "ports": sorted(
+                (
+                    {
+                        "host_ip": port.get("host_ip"),
+                        "published": port.get("published"),
+                        "target": port.get("target"),
+                        "protocol": port.get("protocol"),
+                        "mode": port.get("mode"),
+                    }
+                    for port in service.get("ports") or []
+                ),
+                key=lambda port: json.dumps(port, sort_keys=True),
+            ),
+            "binds": sorted(
+                (
+                    {
+                        "source": mount.get("source"),
+                        "target": mount.get("target"),
+                        "read_only": mount.get("read_only", False),
+                    }
+                    for mount in mounts
+                    if mount.get("type") == "bind"
+                ),
+                key=lambda mount: json.dumps(mount, sort_keys=True),
+            ),
+            "volumes": sorted(
+                (
+                    {
+                        "source": mount.get("source"),
+                        "target": mount.get("target"),
+                        "read_only": mount.get("read_only", False),
+                    }
+                    for mount in mounts
+                    if mount.get("type") == "volume"
+                ),
+                key=lambda mount: json.dumps(mount, sort_keys=True),
+            ),
+            "devices": sorted(
+                (
+                    {
+                        "source": device.get("source"),
+                        "target": device.get("target"),
+                        "permissions": device.get("permissions"),
+                    }
+                    for device in service.get("devices") or []
+                ),
+                key=lambda device: json.dumps(device, sort_keys=True),
+            ),
+            "network_mode": service.get("network_mode"),
+            "networks": sorted((service.get("networks") or {}).keys()),
+            "healthcheck_sha256": stable_hash(healthcheck) if healthcheck else None,
+        }
+
+    volumes = sorted((model.get("volumes") or {}).keys())
+    networks = {
+        name: {
+            "name": network.get("name"),
+            "driver": network.get("driver"),
+            "external": network.get("external", False),
+        }
+        for name, network in sorted((model.get("networks") or {}).items())
+    }
+    return {
+        "kind": "desired",
+        "project_name": args.project_name,
+        "service_count": len(services),
+        "volume_count": len(volumes),
+        "services": services,
+        "volumes": volumes,
+        "networks": networks,
+    }
+
+
+def runtime_inventory(args: Namespace) -> dict[str, object]:
+    ids_result = subprocess.run(
+        [
+            "/usr/bin/docker",
+            "ps",
+            "--all",
+            "--quiet",
+            "--filter",
+            f"label=com.docker.compose.project={args.project_name}",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    container_ids = [line for line in ids_result.stdout.splitlines() if line]
+    inspected = run_json(["/usr/bin/docker", "inspect", *container_ids]) if container_ids else []
+
+    services = {}
+    running_count = 0
+    for container in inspected:
+        labels = container.get("Config", {}).get("Labels") or {}
+        service_name = labels.get("com.docker.compose.service")
+        if not service_name:
+            continue
+        state = container.get("State") or {}
+        if state.get("Running"):
+            running_count += 1
+        host_config = container.get("HostConfig") or {}
+        mounts = container.get("Mounts") or []
+        healthcheck = (container.get("Config") or {}).get("Healthcheck")
+        network_settings = container.get("NetworkSettings") or {}
+        services[service_name] = {
+            "container_name": (container.get("Name") or "").removeprefix("/"),
+            "running": bool(state.get("Running")),
+            "health": (state.get("Health") or {}).get("Status"),
+            "image": (container.get("Config") or {}).get("Image"),
+            "image_id": container.get("Image"),
+            "ports": host_config.get("PortBindings") or {},
+            "binds": sorted(
+                (
+                    {
+                        "source": mount.get("Source"),
+                        "target": mount.get("Destination"),
+                        "read_only": not mount.get("RW", False),
+                    }
+                    for mount in mounts
+                    if mount.get("Type") == "bind"
+                ),
+                key=lambda mount: json.dumps(mount, sort_keys=True),
+            ),
+            "volumes": sorted(
+                (
+                    {
+                        "source": mount.get("Name"),
+                        "target": mount.get("Destination"),
+                        "read_only": not mount.get("RW", False),
+                    }
+                    for mount in mounts
+                    if mount.get("Type") == "volume"
+                ),
+                key=lambda mount: json.dumps(mount, sort_keys=True),
+            ),
+            "devices": sorted(
+                (
+                    {
+                        "source": device.get("PathOnHost"),
+                        "target": device.get("PathInContainer"),
+                        "permissions": device.get("CgroupPermissions"),
+                    }
+                    for device in host_config.get("Devices") or []
+                ),
+                key=lambda device: json.dumps(device, sort_keys=True),
+            ),
+            "network_mode": host_config.get("NetworkMode"),
+            "networks": sorted((network_settings.get("Networks") or {}).keys()),
+            "healthcheck_sha256": stable_hash(healthcheck) if healthcheck else None,
+        }
+
+    volume_result = subprocess.run(
+        [
+            "/usr/bin/docker",
+            "volume",
+            "ls",
+            "--quiet",
+            "--filter",
+            f"label=com.docker.compose.project={args.project_name}",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    project_volumes = sorted(line for line in volume_result.stdout.splitlines() if line)
+    return {
+        "kind": "runtime",
+        "project_name": args.project_name,
+        "container_count": len(services),
+        "running_count": running_count,
+        "project_volume_count": len(project_volumes),
+        "project_volumes": project_volumes,
+        "services": dict(sorted(services.items())),
+    }
+
+
+def parse_args() -> Namespace:
+    parser = ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    desired = subparsers.add_parser("desired")
+    desired.add_argument("--artifact-root", required=True, type=Path)
+    desired.add_argument("--project-directory", required=True, type=Path)
+    desired.add_argument("--env-file", required=True, type=Path)
+    desired.add_argument("--project-name", default="docker-compose")
+    desired.add_argument("--output", type=Path)
+    runtime = subparsers.add_parser("runtime")
+    runtime.add_argument("--project-name", default="docker-compose")
+    runtime.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    inventory = desired_inventory(args) if args.command == "desired" else runtime_inventory(args)
+    encoded = json.dumps(inventory, sort_keys=True, separators=(",", ":")) + "\n"
+    if args.output is None:
+        print(encoded, end="")
+    else:
+        if args.output.exists():
+            raise SystemExit("refusing to overwrite an existing inventory output")
+        args.output.write_text(encoded, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/infra.yml
+++ b/services/infra.yml
@@ -46,7 +46,7 @@ x-backup-volumes: &backup-volumes
   # See the use of BACKUP_EXCLUDE_REGEXP
   - ${GAMES_PATH}/wolf/profile-data/paul/WolfES-DE:/backup/wolf/profile-data/paul/WolfES-DE:ro
   # Sensitive host files remain safe in S3 because backups are GPG-encrypted.
-  - ../.env:/backup/.env:ro
+  - /etc/docker-compose/production.env:/backup/.env:ro
   - ${HOME}/.ssh:/backup/.ssh:ro
   # Required for GPG public-key encryption
   - ./data/backup-gpg-public.asc:/etc/docker-volume-backup/gpg-public.asc:ro


### PR DESCRIPTION
## Summary

- define a 31-file deterministic Compose artifact and canonical content hash
- add a manual main-only host staging workflow with root-only SOPS decryption
- validate staged Compose using explicit project name, stable project directory, and `config --quiet`
- emit secret-free desired/runtime inventories and run `--dry-run create --no-build --pull never`
- point future backup containers at `/etc/docker-compose/production.env`

## Safety

- no Compose pull, build, create, up, restart, removal, orphan removal, or volume operation
- no resolved Compose model or decrypted environment output
- existing checkout and `.env` remain active rollback inputs
- live containers continue using `/home/docker/Projects/docker-compose` until the separately controlled cutover

## Validation

- artifact source/copy/staged hash round trip passed
- Ansible staging syntax passed
- local audit: `changed=0 unreachable=0 failed=0`
- local site check: `changed=0 unreachable=0 failed=0`