### PR TITLE
fix: run artifact hash during check mode

### DIFF
--- a/ansible/roles/compose_stage/tasks/main.yml
+++ b/ansible/roles/compose_stage/tasks/main.yml
@@ -22,6 +22,7 @@
   become: false
   register: compose_stage_controller_hash
   changed_when: false
+  check_mode: false
 
 - name: Require the reviewed controller artifact hash
   ansible.builtin.assert:


### PR DESCRIPTION
## Summary

Run the read-only delegated artifact hash command during Ansible check mode so the reviewed hash assertion has evidence.

## Safety

The failed staging run stopped before any host mutation. This change only enables a controller-side read-only hash command in check mode.