### PR TITLE
fix: validate compose from staged root

### DIFF
--- a/ansible/roles/compose_stage/tasks/main.yml
+++ b/ansible/roles/compose_stage/tasks/main.yml
@@ -203,7 +203,7 @@
           - --project-name
           - "{{ compose_project_name }}"
           - --project-directory
-          - "{{ compose_current_dir }}"
+          - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
           - --env-file
           - "{{ compose_runtime_env_path }}"
           - --file
@@ -223,11 +223,13 @@
           - --artifact-root
           - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
           - --project-directory
-          - "{{ compose_current_dir }}"
+          - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
           - --env-file
           - "{{ compose_runtime_env_path }}"
           - --project-name
           - "{{ compose_project_name }}"
+          - --bind-root-override
+          - "{{ compose_current_dir }}"
           - --output
           - "{{ compose_stage_decrypt_workspace.path }}/staged-model.json"
       become: true
@@ -272,7 +274,7 @@
           - --project-name
           - "{{ compose_project_name }}"
           - --project-directory
-          - "{{ compose_current_dir }}"
+          - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
           - --env-file
           - "{{ compose_runtime_env_path }}"
           - --file

--- a/docs/compose-deployment.md
+++ b/docs/compose-deployment.md
@@ -40,7 +40,7 @@ The existing `/home/docker/Projects/docker-compose` checkout and `.env` remain u
 6. decrypts SOPS only on the host through `/etc/sops/age/keys.txt`;
 7. restores the non-secret dotenv layout in a root-only temporary directory;
 8. atomically installs `/etc/docker-compose/production.env` as `root:root 0600` with `no_log: true`;
-9. validates with explicit project name, project directory, environment file, and `docker compose config --quiet`;
+9. validates with explicit project name, immutable staging project directory, environment file, and `docker compose config --quiet`;
 10. writes root-owned secret-free desired and runtime inventories;
 11. runs `docker compose --dry-run create --no-build --pull never`; and
 12. requires a zero-change staging post-check and complete read-only audit.
@@ -59,7 +59,7 @@ This workflow does not run Compose pull, build, create, up, restart, removal, or
 - network modes and network names; and
 - SHA-256 identities of health-check definitions.
 
-It never emits environment values, resolved commands, labels, or the complete Compose model. The desired inventory resolves relative bind sources against `/srv/docker-compose/current`, not a temporary staging or GitHub checkout.
+It never emits environment values, resolved commands, labels, or the complete Compose model. Compose resolves and dry-runs the immutable staged tree so every include and helper exists; the sanitized desired inventory then translates artifact-relative bind sources to `/srv/docker-compose/current`, never a temporary staging or GitHub checkout.
 
 ## Backup environment mount
 

--- a/scripts/compose-model-inventory.py
+++ b/scripts/compose-model-inventory.py
@@ -14,6 +14,18 @@ def stable_hash(value: object) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+def mapped_bind_source(
+    source: object, artifact_root: Path, bind_root_override: Path | None
+) -> object:
+    if not isinstance(source, str) or bind_root_override is None:
+        return source
+    try:
+        relative_source = Path(source).resolve().relative_to(artifact_root)
+    except ValueError:
+        return source
+    return str(bind_root_override.resolve() / relative_source)
+
+
 def run_json(command: list[str]) -> Any:
     result = subprocess.run(
         command,
@@ -67,7 +79,9 @@ def desired_inventory(args: Namespace) -> dict[str, object]:
             "binds": sorted(
                 (
                     {
-                        "source": mount.get("source"),
+                        "source": mapped_bind_source(
+                            mount.get("source"), artifact_root, args.bind_root_override
+                        ),
                         "target": mount.get("target"),
                         "read_only": mount.get("read_only", False),
                     }
@@ -237,6 +251,7 @@ def parse_args() -> Namespace:
     desired.add_argument("--project-directory", required=True, type=Path)
     desired.add_argument("--env-file", required=True, type=Path)
     desired.add_argument("--project-name", default="docker-compose")
+    desired.add_argument("--bind-root-override", type=Path)
     desired.add_argument("--output", type=Path)
     runtime = subparsers.add_parser("runtime")
     runtime.add_argument("--project-name", default="docker-compose")


### PR DESCRIPTION
## Summary

- resolve Compose includes from the immutable staged artifact during validation and dry run
- translate artifact-relative bind sources to `/srv/docker-compose/current` in the secret-free desired inventory

## Failure boundary

The prior run stopped at `docker compose config --quiet` after publishing the hash-verified staging artifact and inactive root-only environment. It did not reach dry-run and performed no Compose runtime operation. All 41 containers, 33 project volumes, health checks, Tailscale health, and lock baseline remained unchanged.

The existing failed staging artifact remains immutable for evidence; this corrected commit has a new deterministic hash.