### PR TITLE
feat: review staged compose differences

### DIFF
--- a/.github/workflows/compose-stage.yml
+++ b/.github/workflows/compose-stage.yml
@@ -105,6 +105,17 @@ jobs:
           [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
           echo "recap=$recap" >>"$GITHUB_OUTPUT"
 
+      - name: Review the complete secret-free dry run and model differences
+        working-directory: ansible
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ansible-playbook -i inventory/production.yml \
+            playbooks/review-compose-stage.yml \
+            -e "compose_artifact_hash=$ARTIFACT_HASH"
+
       - name: Require zero staging changes after execution
         id: postcheck
         working-directory: ansible

--- a/ansible/playbooks/review-compose-stage.yml
+++ b/ansible/playbooks/review-compose-stage.yml
@@ -1,0 +1,32 @@
+---
+- name: Review staged Compose differences without exposing resolved environment data
+  hosts: docker_host
+  gather_facts: false
+  any_errors_fatal: true
+  vars_files:
+    - "{{ playbook_dir }}/../group_vars/docker_host.yml"
+  tasks:
+    - name: Produce the guarded staging review report
+      ansible.builtin.script:
+        cmd: >-
+          {{ playbook_dir }}/../../scripts/review-compose-stage.py
+          --desired {{ compose_staged_inventory_path }}
+          --runtime {{ compose_runtime_inventory_path }}
+          --artifact-root {{ compose_staging_root }}/{{ compose_artifact_hash }}
+          --project-directory {{ compose_staging_root }}/{{ compose_artifact_hash }}
+          --env-file {{ compose_runtime_env_path }}
+          --project-name {{ compose_project_name }}
+        executable: python
+      become: true
+      register: compose_stage_review_command
+      changed_when: false
+      no_log: true
+
+    - name: Parse the secret-free staging review report
+      ansible.builtin.set_fact:
+        compose_stage_review: "{{ compose_stage_review_command.stdout | from_json }}"
+      no_log: true
+
+    - name: Display only the secret-free staging review report
+      ansible.builtin.debug:
+        var: compose_stage_review

--- a/scripts/review-compose-stage.py
+++ b/scripts/review-compose-stage.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Review staged Compose and runtime inventories without exposing environment data."""
+
+from argparse import ArgumentParser
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+
+ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def load_json(path: Path) -> dict[str, object]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise SystemExit("inventory root must be an object")
+    return value
+
+
+def environment_entries(path: Path) -> tuple[list[str], list[str]]:
+    keys = []
+    values = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, separator, value = line.partition("=")
+        if not separator:
+            raise SystemExit("runtime environment contains an invalid assignment")
+        keys.append(key)
+        if value:
+            values.append(value)
+    return keys, values
+
+
+def service_differences(
+    desired_services: dict[str, object], runtime_services: dict[str, object], field: str
+) -> dict[str, object]:
+    differences = {}
+    for service_name in sorted(set(desired_services) & set(runtime_services)):
+        desired_service = desired_services[service_name]
+        runtime_service = runtime_services[service_name]
+        if not isinstance(desired_service, dict) or not isinstance(runtime_service, dict):
+            raise SystemExit("service inventory entry must be an object")
+        desired_value = desired_service.get(field)
+        runtime_value = runtime_service.get(field)
+        if desired_value != runtime_value:
+            differences[service_name] = {
+                "desired": desired_value,
+                "runtime": runtime_value,
+            }
+    return differences
+
+
+def main() -> None:
+    parser = ArgumentParser()
+    parser.add_argument("--desired", required=True, type=Path)
+    parser.add_argument("--runtime", required=True, type=Path)
+    parser.add_argument("--artifact-root", required=True, type=Path)
+    parser.add_argument("--project-directory", required=True, type=Path)
+    parser.add_argument("--env-file", required=True, type=Path)
+    parser.add_argument("--project-name", default="docker-compose")
+    args = parser.parse_args()
+
+    desired = load_json(args.desired)
+    runtime = load_json(args.runtime)
+    if desired.get("kind") != "desired" or runtime.get("kind") != "runtime":
+        raise SystemExit("inventory kinds are invalid")
+    if desired.get("project_name") != args.project_name or runtime.get("project_name") != args.project_name:
+        raise SystemExit("inventory project name differs from the required project")
+    desired_services = desired.get("services")
+    runtime_services = runtime.get("services")
+    if not isinstance(desired_services, dict) or not isinstance(runtime_services, dict):
+        raise SystemExit("service inventory is invalid")
+
+    command = [
+        "/usr/bin/docker",
+        "compose",
+        "--dry-run",
+        "--project-name",
+        args.project_name,
+        "--project-directory",
+        str(args.project_directory.resolve()),
+        "--env-file",
+        str(args.env_file.resolve()),
+        "--file",
+        str(args.artifact_root.resolve() / "docker-compose.yml"),
+        "create",
+        "--no-build",
+        "--pull",
+        "never",
+    ]
+    dry_run = subprocess.run(
+        command,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    dry_run_output = ANSI_PATTERN.sub("", dry_run.stdout + dry_run.stderr)
+    env_keys, env_values = environment_entries(args.env_file)
+    if any(key in dry_run_output for key in env_keys) or any(
+        len(value) >= 12 and value in dry_run_output for value in env_values
+    ):
+        raise SystemExit("dry-run output contains runtime environment material")
+    dry_run_lines = [line for line in dry_run_output.splitlines() if line]
+
+    desired_names = set(desired_services)
+    runtime_names = set(runtime_services)
+    compared_fields = (
+        "image",
+        "ports",
+        "binds",
+        "volumes",
+        "devices",
+        "network_mode",
+        "networks",
+        "healthcheck_sha256",
+    )
+    differences = {
+        field: service_differences(desired_services, runtime_services, field)
+        for field in compared_fields
+    }
+    report = {
+        "project_name": args.project_name,
+        "desired_service_count": desired.get("service_count"),
+        "runtime_container_count": runtime.get("container_count"),
+        "runtime_running_count": runtime.get("running_count"),
+        "desired_volume_count": desired.get("volume_count"),
+        "runtime_project_volume_count": runtime.get("project_volume_count"),
+        "missing_runtime_services": sorted(desired_names - runtime_names),
+        "unexpected_runtime_services": sorted(runtime_names - desired_names),
+        "difference_counts": {
+            field: len(field_differences)
+            for field, field_differences in differences.items()
+        },
+        "differences": differences,
+        "dry_run": {
+            "line_count": len(dry_run_lines),
+            "sha256": hashlib.sha256(dry_run_output.encode()).hexdigest(),
+            "lines": dry_run_lines,
+        },
+    }
+    print(json.dumps(report, sort_keys=True, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add a root-executed, no-log staging reviewer that emits only sanitized model differences
- capture complete dry-run output only after rejecting environment names and long values
- compare services, images, ports, binds, volumes, devices, network modes, networks, and health-check identities

The review helper is excluded from the deployment artifact, so the already staged artifact hash remains unchanged.