### PR TITLE
fix: trim compose review output

### DIFF
--- a/ansible/playbooks/review-compose-stage.yml
+++ b/ansible/playbooks/review-compose-stage.yml
@@ -25,7 +25,7 @@
     - name: Select the single JSON staging review line
       ansible.builtin.set_fact:
         compose_stage_review_json_lines: >-
-          {{ compose_stage_review_command.stdout_lines | select('match', '^\\{') | list }}
+          {{ compose_stage_review_command.stdout_lines | map('trim') | select('match', '^\\{') | list }}
       no_log: true
 
     - name: Require exactly one guarded staging review object


### PR DESCRIPTION
Trim transport whitespace from no-log script stdout lines before selecting the single guarded JSON review object.