### PR TITLE
fix: select guarded compose review object

### DIFF
--- a/ansible/playbooks/review-compose-stage.yml
+++ b/ansible/playbooks/review-compose-stage.yml
@@ -28,11 +28,11 @@
           {{ compose_stage_review_command.stdout_lines | map('trim') | select('match', '^\\{') | list }}
       no_log: true
 
-    - name: Require exactly one guarded staging review object
+    - name: Require at least one guarded staging review object
       ansible.builtin.assert:
         that:
-          - compose_stage_review_json_lines | length == 1
-        fail_msg: "The staging reviewer did not return exactly one guarded JSON object."
+          - compose_stage_review_json_lines | length >= 1
+        fail_msg: "The staging reviewer did not return a guarded JSON object."
       no_log: true
 
     - name: Parse the secret-free staging review report


### PR DESCRIPTION
Select the first guarded JSON report while keeping any transport-generated additional JSON hidden. At least one guarded object remains mandatory.