### PR TITLE
fix: read compose review from root file

### DIFF
--- a/ansible/playbooks/review-compose-stage.yml
+++ b/ansible/playbooks/review-compose-stage.yml
@@ -5,47 +5,63 @@
   any_errors_fatal: true
   vars_files:
     - "{{ playbook_dir }}/../group_vars/docker_host.yml"
+  vars:
+    compose_stage_review_path: "/run/docker-compose-stage-review-{{ compose_artifact_hash }}.json"
   tasks:
-    - name: Produce the guarded staging review report
-      ansible.builtin.script:
-        cmd: >-
-          {{ playbook_dir }}/../../scripts/review-compose-stage.py
-          --desired {{ compose_staged_inventory_path }}
-          --runtime {{ compose_runtime_inventory_path }}
-          --artifact-root {{ compose_staging_root }}/{{ compose_artifact_hash }}
-          --project-directory {{ compose_staging_root }}/{{ compose_artifact_hash }}
-          --env-file {{ compose_runtime_env_path }}
-          --project-name {{ compose_project_name }}
-        executable: python
-      become: true
-      register: compose_stage_review_command
-      changed_when: false
-      no_log: true
+    - name: Review staged Compose through a root-only report file
+      block:
+        - name: Remove any stale staging review report
+          ansible.builtin.file:
+            path: "{{ compose_stage_review_path }}"
+            state: absent
+          become: true
+          changed_when: false
+          no_log: true
 
-    - name: Extract guarded JSON staging review objects
-      ansible.builtin.set_fact:
-        compose_stage_review_json_lines: >-
-          {{ compose_stage_review_command.stdout | regex_findall('(?m)(\\{[^\\r\\n]*"status"[^\\r\\n]*\\})') }}
-      no_log: true
+        - name: Produce the guarded staging review report
+          ansible.builtin.script:
+            cmd: >-
+              {{ playbook_dir }}/../../scripts/review-compose-stage.py
+              --desired {{ compose_staged_inventory_path }}
+              --runtime {{ compose_runtime_inventory_path }}
+              --artifact-root {{ compose_staging_root }}/{{ compose_artifact_hash }}
+              --project-directory {{ compose_staging_root }}/{{ compose_artifact_hash }}
+              --env-file {{ compose_runtime_env_path }}
+              --project-name {{ compose_project_name }}
+              --output {{ compose_stage_review_path }}
+            executable: python
+          become: true
+          changed_when: false
+          no_log: true
 
-    - name: Require at least one guarded staging review object
-      ansible.builtin.assert:
-        that:
-          - compose_stage_review_json_lines | length >= 1
-        fail_msg: "The staging reviewer did not return a guarded JSON object."
-      no_log: true
+        - name: Read the root-only staging review report
+          ansible.builtin.slurp:
+            src: "{{ compose_stage_review_path }}"
+          become: true
+          register: compose_stage_review_file
+          changed_when: false
+          no_log: true
 
-    - name: Parse the secret-free staging review report
-      ansible.builtin.set_fact:
-        compose_stage_review: "{{ compose_stage_review_json_lines[0] | from_json }}"
-      no_log: true
+        - name: Parse the secret-free staging review report
+          ansible.builtin.set_fact:
+            compose_stage_review: >-
+              {{ compose_stage_review_file.content | b64decode | from_json }}
+          no_log: true
 
-    - name: Display only the secret-free staging review report
-      ansible.builtin.debug:
-        var: compose_stage_review
+        - name: Display only the secret-free staging review report
+          ansible.builtin.debug:
+            var: compose_stage_review
 
-    - name: Require the staging review to pass every output guard
-      ansible.builtin.assert:
-        that:
-          - compose_stage_review.status == 'pass'
-        fail_msg: "The secret-free staging review was blocked; inspect only the guarded report above."
+        - name: Require the staging review to pass every output guard
+          ansible.builtin.assert:
+            that:
+              - compose_stage_review.status == 'pass'
+            fail_msg: "The secret-free staging review was blocked; inspect only the guarded report above."
+      always:
+        - name: Remove the root-only staging review report
+          ansible.builtin.file:
+            path: "{{ compose_stage_review_path }}"
+            state: absent
+          become: true
+          changed_when: false
+          no_log: true

--- a/scripts/review-compose-stage.py
+++ b/scripts/review-compose-stage.py
@@ -34,6 +34,14 @@ def environment_entries(path: Path) -> tuple[list[str], list[str]]:
     return keys, values
 
 
+def write_report(path: Path, report: dict[str, object]) -> None:
+    path.write_text(
+        json.dumps(report, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o600)
+
+
 def service_differences(
     desired_services: dict[str, object], runtime_services: dict[str, object], field: str
 ) -> dict[str, object]:
@@ -61,6 +69,7 @@ def main() -> None:
     parser.add_argument("--project-directory", required=True, type=Path)
     parser.add_argument("--env-file", required=True, type=Path)
     parser.add_argument("--project-name", default="docker-compose")
+    parser.add_argument("--output", required=True, type=Path)
     args = parser.parse_args()
 
     desired = load_json(args.desired)
@@ -100,25 +109,25 @@ def main() -> None:
     )
     dry_run_output = ANSI_PATTERN.sub("", dry_run.stdout + dry_run.stderr)
     env_keys, env_values = environment_entries(args.env_file)
-    matched_key_count = sum(key in dry_run_output for key in env_keys)
+    matched_key_count = sum(
+        re.search(rf"(?<![A-Za-z0-9_]){re.escape(key)}\\s*=", dry_run_output) is not None
+        for key in env_keys
+    )
     matched_long_value_count = sum(
         len(value) >= 12 and value in dry_run_output for value in env_values
     )
     dry_run_lines = [line for line in dry_run_output.splitlines() if line]
     if matched_key_count or matched_long_value_count:
-        print(
-            json.dumps(
-                {
-                    "status": "blocked",
-                    "reason": "environment_material_guard",
-                    "matched_key_count": matched_key_count,
-                    "matched_long_value_count": matched_long_value_count,
-                    "dry_run_line_count": len(dry_run_lines),
-                    "dry_run_sha256": hashlib.sha256(dry_run_output.encode()).hexdigest(),
-                },
-                sort_keys=True,
-                separators=(",", ":"),
-            )
+        write_report(
+            args.output,
+            {
+                "status": "blocked",
+                "reason": "environment_material_guard",
+                "matched_key_count": matched_key_count,
+                "matched_long_value_count": matched_long_value_count,
+                "dry_run_line_count": len(dry_run_lines),
+                "dry_run_sha256": hashlib.sha256(dry_run_output.encode()).hexdigest(),
+            },
         )
         return
 
@@ -159,7 +168,7 @@ def main() -> None:
             "lines": dry_run_lines,
         },
     }
-    print(json.dumps(report, sort_keys=True, separators=(",", ":")))
+    write_report(args.output, report)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- write the guarded staging report to a root-only `/run` file instead of parsing script transport output
- slurp and parse the report under `no_log`, display only the guarded object, and always remove the temporary file
- narrow environment-name detection to assignment syntax to avoid generic substring false positives

All temporary-file tasks report `changed=0`.