### PR TITLE
fix: preserve compose home expansion

### DIFF
--- a/ansible/group_vars/docker_host.yml
+++ b/ansible/group_vars/docker_host.yml
@@ -46,6 +46,7 @@ age_binary_sha256: 2e305637f2a0555305e21c17fb74446acbb39b53135d43d4b744e50c28713
 age_keygen_binary_sha256: c56ef69834e18ca4d3b953117f4481522c35fb6862a5d2871685aa4685893664
 
 compose_project_name: docker-compose
+compose_home_dir: /home/docker
 compose_deployment_root: /srv/docker-compose
 compose_current_dir: /srv/docker-compose/current
 compose_staging_root: /srv/docker-compose/staging

--- a/ansible/playbooks/review-compose-stage.yml
+++ b/ansible/playbooks/review-compose-stage.yml
@@ -33,6 +33,8 @@
           become: true
           changed_when: false
           no_log: true
+          environment:
+            HOME: "{{ compose_home_dir }}"
 
         - name: Read the root-only staging review report
           ansible.builtin.slurp:

--- a/ansible/roles/compose_stage/tasks/main.yml
+++ b/ansible/roles/compose_stage/tasks/main.yml
@@ -213,6 +213,8 @@
       become: true
       changed_when: false
       no_log: true
+      environment:
+        HOME: "{{ compose_home_dir }}"
 
     - name: Produce the secret-free staged model inventory
       ansible.builtin.command:
@@ -235,6 +237,8 @@
       become: true
       changed_when: false
       no_log: true
+      environment:
+        HOME: "{{ compose_home_dir }}"
 
     - name: Produce the secret-free runtime model inventory
       ansible.builtin.command:
@@ -287,6 +291,8 @@
       register: compose_stage_dry_run
       changed_when: false
       no_log: true
+      environment:
+        HOME: "{{ compose_home_dir }}"
 
     - name: Report the reviewed dry-run identity without model data
       ansible.builtin.debug:


### PR DESCRIPTION
## Summary

Pin `HOME=/home/docker` for every root-executed staged Compose resolution and dry run. This preserves the existing `/home/docker/.ssh` backup bind instead of incorrectly resolving it to `/root/.ssh`.