### PR TITLE
chore: expose healthcheck field hashes

### DIFF
--- a/scripts/compose-model-inventory.py
+++ b/scripts/compose-model-inventory.py
@@ -98,6 +98,13 @@ def normalized_healthcheck(healthcheck: object) -> dict[str, object] | None:
     return normalized or None
 
 
+def healthcheck_field_hashes(healthcheck: object) -> dict[str, str]:
+    normalized = normalized_healthcheck(healthcheck)
+    if normalized is None:
+        return {}
+    return {field: stable_hash(value) for field, value in sorted(normalized.items())}
+
+
 def mapped_bind_source(
     source: object, artifact_root: Path, bind_root_override: Path | None
 ) -> object:
@@ -200,6 +207,7 @@ def desired_inventory(args: Namespace) -> dict[str, object]:
             "healthcheck_sha256": (
                 stable_hash(normalized_healthcheck(healthcheck)) if healthcheck else None
             ),
+            "healthcheck_fields_sha256": healthcheck_field_hashes(healthcheck),
         }
 
     volumes = sorted((model.get("volumes") or {}).keys())
@@ -324,6 +332,7 @@ def runtime_inventory(args: Namespace) -> dict[str, object]:
             "healthcheck_sha256": (
                 stable_hash(normalized_healthcheck(healthcheck)) if healthcheck else None
             ),
+            "healthcheck_fields_sha256": healthcheck_field_hashes(healthcheck),
         }
 
     volume_result = subprocess.run(

--- a/scripts/review-compose-stage.py
+++ b/scripts/review-compose-stage.py
@@ -157,6 +157,7 @@ def main() -> None:
         "network_mode",
         "networks",
         "healthcheck_sha256",
+        "healthcheck_fields_sha256",
     )
     differences = {
         field: service_differences(desired_services, runtime_services, field)


### PR DESCRIPTION
Add per-field SHA-256 identities for normalized health checks so representation-only differences can be isolated without exposing commands or values.