### PR TITLE
feat: guard initial compose cutover

### DIFF
--- a/.github/workflows/compose-cutover.yml
+++ b/.github/workflows/compose-cutover.yml
@@ -1,0 +1,166 @@
+name: Cut over to the staged Compose artifact
+
+on:
+  workflow_dispatch:
+    inputs:
+      artifact_sha256:
+        description: Exact reviewed 64-character artifact SHA-256
+        required: true
+        type: string
+      confirmation:
+        description: Enter cutover:<artifact_sha256>
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ansible-production
+  cancel-in-progress: false
+
+env:
+  ANSIBLE_HOST_KEY_CHECKING: "true"
+  ANSIBLE_NOCOLOR: "1"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+jobs:
+  cutover:
+    name: Guarded initial Compose cutover
+    if: vars.COMPOSE_CUTOVER_ENABLED == 'true' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    environment: infrastructure-apply
+
+    steps:
+      - name: Check out the exact main commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Require the exact reviewed artifact and typed confirmation
+        id: artifact
+        env:
+          REQUESTED_HASH: ${{ inputs.artifact_sha256 }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ $REQUESTED_HASH =~ ^[0-9a-f]{64}$ ]]
+          [[ $CONFIRMATION == "cutover:$REQUESTED_HASH" ]]
+          actual_hash=$(python3 scripts/compose-artifact.py hash)
+          [[ $actual_hash == "$REQUESTED_HASH" ]]
+          echo "hash=$actual_hash" >>"$GITHUB_OUTPUT"
+
+      - name: Prepare the restricted apply controller
+        uses: ./.github/actions/ansible-controller
+        with:
+          oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TS_AUDIENCE }}
+          tags: tag:ci-apply
+          target-ip: 100.111.210.72
+          host-key-fingerprint: SHA256:2wHl3xsBkNYprqP99usjZdwj2Rytcc+MtJVErhowVYw
+          accept-subnet-routes: "false"
+
+      - name: Validate inventory, connectivity, and cutover syntax
+        working-directory: ansible
+        shell: bash
+        run: |
+          set -euo pipefail
+          ansible-inventory -i inventory/production.yml --graph
+          ansible-playbook -i inventory/production.yml --syntax-check playbooks/cutover-compose.yml
+          ansible -i inventory/production.yml docker_host -m ansible.builtin.ping
+
+      - name: Require a zero-change pre-cutover audit
+        id: preaudit
+        working-directory: ansible
+        shell: bash
+        run: |
+          set -euo pipefail
+          audit_log="$RUNNER_TEMP/compose-cutover-preaudit.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/audit.yml --check --diff | tee "$audit_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$audit_log" docker-host-production)
+          [[ $(jq -r '.changed' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Review the exact initial cutover plan
+        id: plan
+        working-directory: ansible
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          plan_log="$RUNNER_TEMP/compose-cutover-plan.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/cutover-compose.yml --check --diff \
+            -e "compose_artifact_hash=$ARTIFACT_HASH" | tee "$plan_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$plan_log" docker-host-production)
+          [[ $(jq -r '.changed' <<<"$recap") == 1 ]]
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Perform the separately confirmed cutover
+        id: apply
+        working-directory: ansible
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          apply_log="$RUNNER_TEMP/compose-cutover-apply.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/cutover-compose.yml \
+            -e "compose_artifact_hash=$ARTIFACT_HASH" \
+            -e compose_cutover_confirmed=true | tee "$apply_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$apply_log" docker-host-production)
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Require a zero-change post-cutover audit
+        id: postaudit
+        working-directory: ansible
+        shell: bash
+        run: |
+          set -euo pipefail
+          audit_log="$RUNNER_TEMP/compose-cutover-postaudit.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/audit.yml --check --diff | tee "$audit_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$audit_log" docker-host-production)
+          [[ $(jq -r '.changed' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Summarize the cutover evidence
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+          PREAUDIT_RECAP: ${{ steps.preaudit.outputs.recap }}
+          PLAN_RECAP: ${{ steps.plan.outputs.recap }}
+          APPLY_RECAP: ${{ steps.apply.outputs.recap }}
+          POSTAUDIT_RECAP: ${{ steps.postaudit.outputs.recap }}
+        shell: bash
+        run: |
+          {
+            echo "### Initial Compose cutover"
+            echo
+            echo "- Commit: \`$GITHUB_SHA\`"
+            echo "- Artifact SHA-256: \`$ARTIFACT_HASH\`"
+            echo "- Pre-cutover audit: \`$PREAUDIT_RECAP\`"
+            echo "- Reviewed plan: \`$PLAN_RECAP\`"
+            echo "- Cutover: \`$APPLY_RECAP\`"
+            echo "- Zero-change post-cutover audit: \`$POSTAUDIT_RECAP\`"
+            echo
+            echo "The command prohibited pulls, builds, removals, and orphan removal."
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/compose-rollback.yml
+++ b/.github/workflows/compose-rollback.yml
@@ -1,0 +1,163 @@
+name: Roll back the initial Compose cutover
+
+on:
+  workflow_dispatch:
+    inputs:
+      deployed_artifact_sha256:
+        description: Exact deployed 64-character artifact SHA-256
+        required: true
+        type: string
+      confirmation:
+        description: Enter rollback:<deployed_artifact_sha256>
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ansible-production
+  cancel-in-progress: false
+
+env:
+  ANSIBLE_HOST_KEY_CHECKING: "true"
+  ANSIBLE_NOCOLOR: "1"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+jobs:
+  rollback:
+    name: Guarded initial Compose rollback
+    if: vars.COMPOSE_ROLLBACK_ENABLED == 'true' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    environment: infrastructure-apply
+
+    steps:
+      - name: Check out the exact main commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Require the exact deployed artifact and typed confirmation
+        id: artifact
+        env:
+          DEPLOYED_HASH: ${{ inputs.deployed_artifact_sha256 }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ $DEPLOYED_HASH =~ ^[0-9a-f]{64}$ ]]
+          [[ $CONFIRMATION == "rollback:$DEPLOYED_HASH" ]]
+          echo "hash=$DEPLOYED_HASH" >>"$GITHUB_OUTPUT"
+
+      - name: Prepare the restricted apply controller
+        uses: ./.github/actions/ansible-controller
+        with:
+          oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TS_AUDIENCE }}
+          tags: tag:ci-apply
+          target-ip: 100.111.210.72
+          host-key-fingerprint: SHA256:2wHl3xsBkNYprqP99usjZdwj2Rytcc+MtJVErhowVYw
+          accept-subnet-routes: "false"
+
+      - name: Validate inventory, connectivity, and rollback syntax
+        working-directory: ansible
+        shell: bash
+        run: |
+          set -euo pipefail
+          ansible-inventory -i inventory/production.yml --graph
+          ansible-playbook -i inventory/production.yml --syntax-check playbooks/rollback-compose.yml
+          ansible -i inventory/production.yml docker_host -m ansible.builtin.ping
+
+      - name: Require a zero-change pre-rollback audit
+        id: preaudit
+        working-directory: ansible
+        shell: bash
+        run: |
+          set -euo pipefail
+          audit_log="$RUNNER_TEMP/compose-rollback-preaudit.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/audit.yml --check --diff | tee "$audit_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$audit_log" docker-host-production)
+          [[ $(jq -r '.changed' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Review the exact rollback plan
+        id: plan
+        working-directory: ansible
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          plan_log="$RUNNER_TEMP/compose-rollback-plan.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/rollback-compose.yml --check --diff \
+            -e "compose_artifact_hash=$ARTIFACT_HASH" | tee "$plan_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$plan_log" docker-host-production)
+          [[ $(jq -r '.changed' <<<"$recap") == 1 ]]
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Perform the separately confirmed rollback
+        id: apply
+        working-directory: ansible
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          apply_log="$RUNNER_TEMP/compose-rollback-apply.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/rollback-compose.yml \
+            -e "compose_artifact_hash=$ARTIFACT_HASH" \
+            -e compose_rollback_confirmed=true | tee "$apply_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$apply_log" docker-host-production)
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Require a zero-change post-rollback audit
+        id: postaudit
+        working-directory: ansible
+        shell: bash
+        run: |
+          set -euo pipefail
+          audit_log="$RUNNER_TEMP/compose-rollback-postaudit.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/audit.yml --check --diff | tee "$audit_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$audit_log" docker-host-production)
+          [[ $(jq -r '.changed' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Summarize rollback evidence
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+          PREAUDIT_RECAP: ${{ steps.preaudit.outputs.recap }}
+          PLAN_RECAP: ${{ steps.plan.outputs.recap }}
+          APPLY_RECAP: ${{ steps.apply.outputs.recap }}
+          POSTAUDIT_RECAP: ${{ steps.postaudit.outputs.recap }}
+        shell: bash
+        run: |
+          {
+            echo "### Initial Compose rollback"
+            echo
+            echo "- Former artifact SHA-256: \`$ARTIFACT_HASH\`"
+            echo "- Pre-rollback audit: \`$PREAUDIT_RECAP\`"
+            echo "- Reviewed plan: \`$PLAN_RECAP\`"
+            echo "- Rollback: \`$APPLY_RECAP\`"
+            echo "- Zero-change post-rollback audit: \`$POSTAUDIT_RECAP\`"
+            echo
+            echo "The command prohibited pulls, builds, removals, and orphan removal."
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/compose-stage.yml
+++ b/.github/workflows/compose-stage.yml
@@ -116,6 +116,25 @@ jobs:
             playbooks/review-compose-stage.yml \
             -e "compose_artifact_hash=$ARTIFACT_HASH"
 
+      - name: Review the disabled initial cutover in check mode
+        id: cutoverplan
+        working-directory: ansible
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cutover_log="$RUNNER_TEMP/compose-cutover-plan.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/cutover-compose.yml --check --diff \
+            -e "compose_artifact_hash=$ARTIFACT_HASH" | tee "$cutover_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$cutover_log" docker-host-production)
+          [[ $(jq -r '.changed' <<<"$recap") == 1 ]]
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
       - name: Require zero staging changes after execution
         id: postcheck
         working-directory: ansible
@@ -158,6 +177,7 @@ jobs:
           ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
           PLAN_RECAP: ${{ steps.plan.outputs.recap }}
           APPLY_RECAP: ${{ steps.apply.outputs.recap }}
+          CUTOVER_PLAN_RECAP: ${{ steps.cutoverplan.outputs.recap }}
           POSTCHECK_RECAP: ${{ steps.postcheck.outputs.recap }}
           AUDIT_RECAP: ${{ steps.audit.outputs.recap }}
         shell: bash
@@ -169,6 +189,7 @@ jobs:
             echo "- Artifact SHA-256: \`$ARTIFACT_HASH\`"
             echo "- Check-mode recap: \`$PLAN_RECAP\`"
             echo "- Staging recap: \`$APPLY_RECAP\`"
+            echo "- Disabled cutover check-mode recap: \`$CUTOVER_PLAN_RECAP\`"
             echo "- Zero-change post-check: \`$POSTCHECK_RECAP\`"
             echo "- Full audit: \`$AUDIT_RECAP\`"
             echo

--- a/ansible/group_vars/docker_host.yml
+++ b/ansible/group_vars/docker_host.yml
@@ -56,6 +56,23 @@ compose_age_identity_path: /etc/sops/age/keys.txt
 compose_deployed_hash_path: /var/lib/docker-compose/deployed.sha256
 compose_staged_inventory_path: /var/lib/docker-compose/staged-model.json
 compose_runtime_inventory_path: /var/lib/docker-compose/runtime-model.json
+compose_initial_recreate_services:
+  - bookshelf
+  - caddy
+  - caro-tachidesk
+  - daily-local-backup
+  - flaresolverr
+  - gluetun
+  - litellm
+  - prowlarr
+  - qbittorrent
+  - radarr
+  - radarr-4k
+  - sabnzbd
+  - seerr
+  - sonarr
+  - tachidesk
+  - weekly-remote-backup
 
 audit_expected_declared_volume_count: 30
 audit_expected_compose_project_volume_count: 33

--- a/ansible/playbooks/cutover-compose.yml
+++ b/ansible/playbooks/cutover-compose.yml
@@ -1,0 +1,25 @@
+---
+- name: Perform the separately approved initial Compose cutover
+  hosts: docker_host
+  gather_facts: true
+  any_errors_fatal: true
+  vars_files:
+    - "{{ playbook_dir }}/../group_vars/docker_host.yml"
+  pre_tasks:
+    - name: Acquire the host-side production apply lock
+      ansible.builtin.import_role:
+        name: apply_lock
+      vars:
+        iac_apply_lock_action: acquire
+  roles:
+    - role: compose_cutover
+  post_tasks:
+    - name: Verify the complete running service baseline after cutover
+      ansible.builtin.import_role:
+        name: health
+
+    - name: Release the host-side production apply lock after successful verification
+      ansible.builtin.import_role:
+        name: apply_lock
+      vars:
+        iac_apply_lock_action: release

--- a/ansible/playbooks/rollback-compose.yml
+++ b/ansible/playbooks/rollback-compose.yml
@@ -1,0 +1,25 @@
+---
+- name: Perform the separately approved initial Compose rollback
+  hosts: docker_host
+  gather_facts: true
+  any_errors_fatal: true
+  vars_files:
+    - "{{ playbook_dir }}/../group_vars/docker_host.yml"
+  pre_tasks:
+    - name: Acquire the host-side production apply lock
+      ansible.builtin.import_role:
+        name: apply_lock
+      vars:
+        iac_apply_lock_action: acquire
+  roles:
+    - role: compose_rollback
+  post_tasks:
+    - name: Verify the complete running service baseline after rollback
+      ansible.builtin.import_role:
+        name: health
+
+    - name: Release the host-side production apply lock after successful verification
+      ansible.builtin.import_role:
+        name: apply_lock
+      vars:
+        iac_apply_lock_action: release

--- a/ansible/roles/compose_cutover/tasks/main.yml
+++ b/ansible/roles/compose_cutover/tasks/main.yml
@@ -1,0 +1,227 @@
+---
+- name: Validate the initial Compose cutover contract
+  ansible.builtin.assert:
+    that:
+      - compose_artifact_hash is match('^[0-9a-f]{64}$')
+      - ansible_check_mode or (compose_cutover_confirmed | default(false) | ansible.builtin.bool)
+    fail_msg: >-
+      Initial Compose cutover requires the reviewed artifact hash and compose_cutover_confirmed=true
+      outside check mode.
+
+- name: Inspect cutover inputs and rollback paths
+  ansible.builtin.stat:
+    path: "{{ item }}"
+    get_checksum: false
+    get_mime: false
+  become: true
+  register: compose_cutover_paths
+  loop:
+    - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
+    - "{{ compose_current_dir }}"
+    - "{{ compose_runtime_env_path }}"
+    - "{{ audit_compose_project_dir }}/docker-compose.yml"
+    - "{{ audit_env_path }}"
+    - "{{ compose_deployed_hash_path }}"
+
+- name: Inspect the inactive current deployment directory
+  ansible.builtin.find:
+    paths: "{{ compose_current_dir }}"
+    hidden: true
+    recurse: false
+    file_type: any
+  become: true
+  register: compose_cutover_current_entries
+  when: compose_cutover_paths.results[1].stat.isdir | default(false)
+
+- name: Require staged inputs and untouched initial rollback inputs
+  ansible.builtin.assert:
+    that:
+      - compose_cutover_paths.results[0].stat.isdir | default(false)
+      - compose_cutover_paths.results[1].stat.isdir | default(false)
+      - compose_cutover_current_entries.matched == 0
+      - compose_cutover_paths.results[2].stat.isreg | default(false)
+      - compose_cutover_paths.results[2].stat.pw_name == 'root'
+      - compose_cutover_paths.results[2].stat.gr_name == 'root'
+      - compose_cutover_paths.results[2].stat.mode == '0600'
+      - compose_cutover_paths.results[3].stat.isreg | default(false)
+      - compose_cutover_paths.results[4].stat.isreg | default(false)
+      - not (compose_cutover_paths.results[5].stat.exists | default(false))
+    fail_msg: >-
+      Cutover inputs differ from the reviewed initial state. The staged artifact, empty current directory,
+      root-only runtime environment, untouched legacy checkout/environment, and absent deployed hash are mandatory.
+
+- name: Recompute the staged artifact identity
+  ansible.builtin.command:
+    argv:
+      - python
+      - "{{ compose_staging_root }}/{{ compose_artifact_hash }}/scripts/compose-artifact.py"
+      - --root
+      - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
+      - --no-git
+      - hash
+  become: true
+  register: compose_cutover_staged_hash
+  changed_when: false
+  check_mode: false
+
+- name: Require the exact reviewed staged artifact
+  ansible.builtin.assert:
+    that:
+      - compose_cutover_staged_hash.stdout == compose_artifact_hash
+    fail_msg: "Staged artifact identity differs from the reviewed cutover hash."
+
+- name: Re-run the exact guarded pre-cutover dry run
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/docker
+      - compose
+      - --dry-run
+      - --project-name
+      - "{{ compose_project_name }}"
+      - --project-directory
+      - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
+      - --env-file
+      - "{{ compose_runtime_env_path }}"
+      - --file
+      - "{{ compose_staging_root }}/{{ compose_artifact_hash }}/docker-compose.yml"
+      - create
+      - --no-build
+      - --pull
+      - never
+  become: true
+  environment:
+    HOME: "{{ compose_home_dir }}"
+  register: compose_cutover_dry_run
+  changed_when: false
+  check_mode: false
+  no_log: true
+
+- name: Extract the exact proposed recreation set
+  ansible.builtin.set_fact:
+    compose_cutover_recreate_services: >-
+      {{ ((compose_cutover_dry_run.stdout_lines + compose_cutover_dry_run.stderr_lines)
+          | select('search', ' Container [a-z0-9-]+ Recreate $')
+          | map('regex_replace', '^.* Container ([a-z0-9-]+) Recreate $', '\\1')
+          | unique | sort) }}
+    compose_cutover_forbidden_action_lines: >-
+      {{ ((compose_cutover_dry_run.stdout_lines + compose_cutover_dry_run.stderr_lines)
+          | select('search', ' Container .* (Creating|Removing|Removed) $') | list) }}
+  no_log: true
+
+- name: Require only the reviewed recreation set
+  ansible.builtin.assert:
+    that:
+      - compose_cutover_recreate_services == compose_initial_recreate_services | sort
+      - compose_cutover_forbidden_action_lines | length == 0
+    fail_msg: >-
+      The pre-cutover dry run differs from the reviewed recreation set or proposes a create/removal action.
+  no_log: true
+
+- name: Report the check-mode cutover boundary
+  ansible.builtin.debug:
+    msg:
+      artifact_hash: "{{ compose_artifact_hash }}"
+      recreation_count: "{{ compose_cutover_recreate_services | length }}"
+      legacy_rollback_project: "{{ audit_compose_project_dir }}"
+  changed_when: true
+  when: ansible_check_mode
+
+- name: Publish and converge the reviewed initial deployment
+  when: not ansible_check_mode
+  block:
+    - name: Copy the immutable staged artifact into the inactive current directory
+      ansible.builtin.copy:
+        src: "{{ compose_staging_root }}/{{ compose_artifact_hash }}/"
+        dest: "{{ compose_current_dir }}/"
+        remote_src: true
+        owner: root
+        group: root
+        mode: preserve
+        directory_mode: "0755"
+      become: true
+
+    - name: Recompute the published current artifact identity
+      ansible.builtin.command:
+        argv:
+          - python
+          - "{{ compose_current_dir }}/scripts/compose-artifact.py"
+          - --root
+          - "{{ compose_current_dir }}"
+          - --no-git
+          - hash
+      become: true
+      register: compose_cutover_current_hash
+      changed_when: false
+
+    - name: Require the exact current artifact before Docker convergence
+      ansible.builtin.assert:
+        that:
+          - compose_cutover_current_hash.stdout == compose_artifact_hash
+        fail_msg: "Published current artifact differs from the reviewed hash; Docker was not converged."
+
+    - name: Converge the reviewed project without pulls, builds, removals, or orphan removal
+      ansible.builtin.command:
+        argv:
+          - /usr/bin/docker
+          - compose
+          - --project-name
+          - "{{ compose_project_name }}"
+          - --project-directory
+          - "{{ compose_current_dir }}"
+          - --env-file
+          - "{{ compose_runtime_env_path }}"
+          - --file
+          - "{{ compose_current_dir }}/docker-compose.yml"
+          - up
+          - --detach
+          - --no-build
+          - --pull
+          - never
+      become: true
+      environment:
+        HOME: "{{ compose_home_dir }}"
+      register: compose_cutover_converge
+      no_log: true
+
+    - name: Verify no further Compose convergence is proposed
+      ansible.builtin.command:
+        argv:
+          - /usr/bin/docker
+          - compose
+          - --dry-run
+          - --project-name
+          - "{{ compose_project_name }}"
+          - --project-directory
+          - "{{ compose_current_dir }}"
+          - --env-file
+          - "{{ compose_runtime_env_path }}"
+          - --file
+          - "{{ compose_current_dir }}/docker-compose.yml"
+          - create
+          - --no-build
+          - --pull
+          - never
+      become: true
+      environment:
+        HOME: "{{ compose_home_dir }}"
+      register: compose_cutover_post_dry_run
+      changed_when: false
+      no_log: true
+
+    - name: Require an idempotent post-cutover dry run
+      ansible.builtin.assert:
+        that:
+          - >-
+            ((compose_cutover_post_dry_run.stdout_lines + compose_cutover_post_dry_run.stderr_lines)
+            | select('search', ' Container .* (Create|Recreate|Remove) ') | list | length) == 0
+        fail_msg: "Post-cutover dry run still proposes container convergence."
+      no_log: true
+
+    - name: Record the deployed artifact identity atomically
+      ansible.builtin.copy:
+        content: "{{ compose_artifact_hash }}\n"
+        dest: "{{ compose_deployed_hash_path }}"
+        owner: root
+        group: root
+        mode: "0600"
+      become: true

--- a/ansible/roles/compose_rollback/tasks/main.yml
+++ b/ansible/roles/compose_rollback/tasks/main.yml
@@ -1,0 +1,172 @@
+---
+- name: Validate the initial Compose rollback contract
+  ansible.builtin.assert:
+    that:
+      - compose_artifact_hash is match('^[0-9a-f]{64}$')
+      - ansible_check_mode or (compose_rollback_confirmed | default(false) | ansible.builtin.bool)
+    fail_msg: >-
+      Initial Compose rollback requires the deployed artifact hash and compose_rollback_confirmed=true
+      outside check mode.
+
+- name: Inspect rollback inputs
+  ansible.builtin.stat:
+    path: "{{ item }}"
+    get_checksum: false
+    get_mime: false
+  become: true
+  register: compose_rollback_paths
+  loop:
+    - "{{ compose_current_dir }}"
+    - "{{ compose_runtime_env_path }}"
+    - "{{ audit_compose_project_dir }}/docker-compose.yml"
+    - "{{ audit_env_path }}"
+    - "{{ compose_deployed_hash_path }}"
+
+- name: Require both current and untouched legacy rollback inputs
+  ansible.builtin.assert:
+    that:
+      - compose_rollback_paths.results[0].stat.isdir | default(false)
+      - compose_rollback_paths.results[1].stat.isreg | default(false)
+      - compose_rollback_paths.results[2].stat.isreg | default(false)
+      - compose_rollback_paths.results[3].stat.isreg | default(false)
+      - compose_rollback_paths.results[4].stat.isreg | default(false)
+    fail_msg: "Current deployment or untouched initial legacy rollback inputs are missing."
+
+- name: Read the deployed artifact identity without displaying it
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/cat
+      - "{{ compose_deployed_hash_path }}"
+  become: true
+  register: compose_rollback_deployed_hash
+  changed_when: false
+  check_mode: false
+  no_log: true
+
+- name: Require the exact deployed artifact selected for rollback
+  ansible.builtin.assert:
+    that:
+      - compose_rollback_deployed_hash.stdout == compose_artifact_hash
+    fail_msg: "Deployed artifact identity differs from the separately reviewed rollback hash."
+  no_log: true
+
+- name: Re-run the exact guarded legacy rollback dry run
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/docker
+      - compose
+      - --dry-run
+      - --project-name
+      - "{{ compose_project_name }}"
+      - --project-directory
+      - "{{ audit_compose_project_dir }}"
+      - --env-file
+      - "{{ audit_env_path }}"
+      - --file
+      - "{{ audit_compose_project_dir }}/docker-compose.yml"
+      - create
+      - --no-build
+      - --pull
+      - never
+  become: true
+  environment:
+    HOME: "{{ compose_home_dir }}"
+  register: compose_rollback_dry_run
+  changed_when: false
+  check_mode: false
+  no_log: true
+
+- name: Extract the exact proposed rollback recreation set
+  ansible.builtin.set_fact:
+    compose_rollback_recreate_services: >-
+      {{ ((compose_rollback_dry_run.stdout_lines + compose_rollback_dry_run.stderr_lines)
+          | select('search', ' Container [a-z0-9-]+ Recreate $')
+          | map('regex_replace', '^.* Container ([a-z0-9-]+) Recreate $', '\\1')
+          | unique | sort) }}
+    compose_rollback_forbidden_action_lines: >-
+      {{ ((compose_rollback_dry_run.stdout_lines + compose_rollback_dry_run.stderr_lines)
+          | select('search', ' Container .* (Creating|Removing|Removed) $') | list) }}
+  no_log: true
+
+- name: Require only the reviewed rollback recreation set
+  ansible.builtin.assert:
+    that:
+      - compose_rollback_recreate_services == compose_initial_recreate_services | sort
+      - compose_rollback_forbidden_action_lines | length == 0
+    fail_msg: "Rollback dry run differs from the reviewed recreation set or proposes create/removal."
+  no_log: true
+
+- name: Report the check-mode rollback boundary
+  ansible.builtin.debug:
+    msg:
+      deployed_artifact_hash: "{{ compose_artifact_hash }}"
+      recreation_count: "{{ compose_rollback_recreate_services | length }}"
+      rollback_project: "{{ audit_compose_project_dir }}"
+  changed_when: true
+  when: ansible_check_mode
+
+- name: Re-converge the untouched legacy project
+  when: not ansible_check_mode
+  block:
+    - name: Converge the legacy project without pulls, builds, removals, or orphan removal
+      ansible.builtin.command:
+        argv:
+          - /usr/bin/docker
+          - compose
+          - --project-name
+          - "{{ compose_project_name }}"
+          - --project-directory
+          - "{{ audit_compose_project_dir }}"
+          - --env-file
+          - "{{ audit_env_path }}"
+          - --file
+          - "{{ audit_compose_project_dir }}/docker-compose.yml"
+          - up
+          - --detach
+          - --no-build
+          - --pull
+          - never
+      become: true
+      environment:
+        HOME: "{{ compose_home_dir }}"
+      no_log: true
+
+    - name: Verify no further legacy Compose convergence is proposed
+      ansible.builtin.command:
+        argv:
+          - /usr/bin/docker
+          - compose
+          - --dry-run
+          - --project-name
+          - "{{ compose_project_name }}"
+          - --project-directory
+          - "{{ audit_compose_project_dir }}"
+          - --env-file
+          - "{{ audit_env_path }}"
+          - --file
+          - "{{ audit_compose_project_dir }}/docker-compose.yml"
+          - create
+          - --no-build
+          - --pull
+          - never
+      become: true
+      environment:
+        HOME: "{{ compose_home_dir }}"
+      register: compose_rollback_post_dry_run
+      changed_when: false
+      no_log: true
+
+    - name: Require an idempotent post-rollback dry run
+      ansible.builtin.assert:
+        that:
+          - >-
+            ((compose_rollback_post_dry_run.stdout_lines + compose_rollback_post_dry_run.stderr_lines)
+            | select('search', ' Container .* (Create|Recreate|Remove) ') | list | length) == 0
+        fail_msg: "Post-rollback dry run still proposes container convergence."
+      no_log: true
+
+    - name: Remove the active stable-deployment identity after rollback
+      ansible.builtin.file:
+        path: "{{ compose_deployed_hash_path }}"
+        state: absent
+      become: true

--- a/docs/compose-deployment.md
+++ b/docs/compose-deployment.md
@@ -76,3 +76,16 @@ The backup services now declare `/etc/docker-compose/production.env:/backup/.env
 ## Cutover boundary
 
 Phase 3 may populate staging, the empty stable directories, and the inactive root-only environment file. It must not synchronize an artifact into `current`, change runtime Compose labels, pull images, or converge containers. Those actions remain Phase 4 maintenance-window work.
+
+The Phase 4 implementation is fail-closed and inactive by default. `.github/workflows/compose-cutover.yml` requires all of the following before its job can run:
+
+- repository variable `COMPOSE_CUTOVER_ENABLED=true`;
+- the protected `infrastructure-apply` environment;
+- `main` at the exact reviewed artifact commit;
+- the exact 64-character staged artifact hash;
+- typed confirmation `cutover:<artifact-sha256>`; and
+- a zero-change full audit plus a check-mode plan that proposes exactly the 16 reviewed recreations and no creates or removals.
+
+The role copies the already immutable artifact into the previously empty `current` directory, recomputes its hash, and runs only `docker compose up --detach --no-build --pull never` with explicit project name, project directory, environment file, and Compose file. It never passes `--remove-orphans`. A successful run requires an idempotent post-cutover dry run, all 41 services running, healthy Gluetun and Seerr, and a zero-change full audit before recording the deployed hash.
+
+There is no automatic rollback. A failure intentionally leaves the persistent production lock in place for inspection. The untouched `/home/docker/Projects/docker-compose` checkout and `.env` remain the initial rollback inputs. `.github/workflows/compose-rollback.yml` is separately disabled behind `COMPOSE_ROLLBACK_ENABLED=true`, requires typed `rollback:<deployed-artifact-sha256>` confirmation and another protected-environment approval, and applies the same no-pull/no-build/no-removal constraints. Lock removal after a failed operation is always a separate reviewed action.


### PR DESCRIPTION
## Summary

- add disabled-by-default, typed-confirmation initial cutover and rollback workflows
- require exact artifact identity and exact 16-service recreation sets with no creates/removals
- prohibit pulls, builds, orphan removal, and automatic rollback
- retain the persistent production lock on failure and require zero-change audits after success
- add a check-mode-only cutover review to the staging workflow

No Docker convergence is enabled or executed by this PR. Both mutation workflows require repository enable variables that remain unset.