### PR TITLE
fix: disable ansi in compose plans

### DIFF
--- a/ansible/roles/compose_cutover/tasks/main.yml
+++ b/ansible/roles/compose_cutover/tasks/main.yml
@@ -75,6 +75,8 @@
     argv:
       - /usr/bin/docker
       - compose
+      - --ansi
+      - never
       - --dry-run
       - --project-name
       - "{{ compose_project_name }}"
@@ -194,6 +196,8 @@
         argv:
           - /usr/bin/docker
           - compose
+          - --ansi
+          - never
           - --dry-run
           - --project-name
           - "{{ compose_project_name }}"

--- a/ansible/roles/compose_rollback/tasks/main.yml
+++ b/ansible/roles/compose_rollback/tasks/main.yml
@@ -55,6 +55,8 @@
     argv:
       - /usr/bin/docker
       - compose
+      - --ansi
+      - never
       - --dry-run
       - --project-name
       - "{{ compose_project_name }}"
@@ -142,6 +144,8 @@
         argv:
           - /usr/bin/docker
           - compose
+          - --ansi
+          - never
           - --dry-run
           - --project-name
           - "{{ compose_project_name }}"


### PR DESCRIPTION
Disable Docker Compose ANSI progress formatting for guarded cutover and rollback dry-run parsing.