### PR TITLE
fix: extract compose cutover actions

### DIFF
--- a/ansible/roles/compose_cutover/tasks/main.yml
+++ b/ansible/roles/compose_cutover/tasks/main.yml
@@ -101,13 +101,11 @@
 - name: Extract the exact proposed recreation set
   ansible.builtin.set_fact:
     compose_cutover_recreate_services: >-
-      {{ ((compose_cutover_dry_run.stdout_lines + compose_cutover_dry_run.stderr_lines)
-          | select('search', ' Container [a-z0-9-]+ Recreate\\s*$')
-          | map('regex_replace', '^.* Container ([a-z0-9-]+) Recreate\\s*$', '\\1')
-          | unique | sort) }}
+      {{ ((compose_cutover_dry_run.stdout ~ '\n' ~ compose_cutover_dry_run.stderr)
+          | regex_findall('Container\\s+([a-z0-9-]+)\\s+Recreate') | unique | sort) }}
     compose_cutover_forbidden_action_lines: >-
-      {{ ((compose_cutover_dry_run.stdout_lines + compose_cutover_dry_run.stderr_lines)
-          | select('search', ' Container .* (Creating|Removing|Removed)\\s*$') | list) }}
+      {{ ((compose_cutover_dry_run.stdout ~ '\n' ~ compose_cutover_dry_run.stderr)
+          | regex_findall('Container\\s+[a-z0-9-]+\\s+(?:Creating|Removing|Removed)')) }}
   no_log: true
 
 - name: Report the secret-free proposed recreation set

--- a/ansible/roles/compose_rollback/tasks/main.yml
+++ b/ansible/roles/compose_rollback/tasks/main.yml
@@ -81,13 +81,11 @@
 - name: Extract the exact proposed rollback recreation set
   ansible.builtin.set_fact:
     compose_rollback_recreate_services: >-
-      {{ ((compose_rollback_dry_run.stdout_lines + compose_rollback_dry_run.stderr_lines)
-          | select('search', ' Container [a-z0-9-]+ Recreate\\s*$')
-          | map('regex_replace', '^.* Container ([a-z0-9-]+) Recreate\\s*$', '\\1')
-          | unique | sort) }}
+      {{ ((compose_rollback_dry_run.stdout ~ '\n' ~ compose_rollback_dry_run.stderr)
+          | regex_findall('Container\\s+([a-z0-9-]+)\\s+Recreate') | unique | sort) }}
     compose_rollback_forbidden_action_lines: >-
-      {{ ((compose_rollback_dry_run.stdout_lines + compose_rollback_dry_run.stderr_lines)
-          | select('search', ' Container .* (Creating|Removing|Removed)\\s*$') | list) }}
+      {{ ((compose_rollback_dry_run.stdout ~ '\n' ~ compose_rollback_dry_run.stderr)
+          | regex_findall('Container\\s+[a-z0-9-]+\\s+(?:Creating|Removing|Removed)')) }}
   no_log: true
 
 - name: Report the secret-free proposed rollback recreation set


### PR DESCRIPTION
Extract guarded recreation names directly from the combined no-log Compose output instead of relying on progress-line boundaries.