### PR TITLE
fix: guard compose action plans

### DIFF
--- a/ansible/roles/compose_cutover/tasks/main.yml
+++ b/ansible/roles/compose_cutover/tasks/main.yml
@@ -70,42 +70,55 @@
       - compose_cutover_staged_hash.stdout == compose_artifact_hash
     fail_msg: "Staged artifact identity differs from the reviewed cutover hash."
 
-- name: Re-run the exact guarded pre-cutover dry run
-  ansible.builtin.command:
-    argv:
-      - /usr/bin/docker
-      - compose
-      - --ansi
-      - never
-      - --dry-run
-      - --project-name
-      - "{{ compose_project_name }}"
-      - --project-directory
-      - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
-      - --env-file
-      - "{{ compose_runtime_env_path }}"
-      - --file
-      - "{{ compose_staging_root }}/{{ compose_artifact_hash }}/docker-compose.yml"
-      - create
-      - --no-build
-      - --pull
-      - never
+- name: Remove any stale pre-cutover action plan
+  ansible.builtin.file:
+    path: /run/docker-compose-cutover-plan.json
+    state: absent
+  become: true
+  changed_when: false
+  no_log: true
+
+- name: Produce the root-only pre-cutover action plan
+  ansible.builtin.script:
+    cmd: >-
+      {{ role_path }}/../../../scripts/compose-action-plan.py
+      --project-name {{ compose_project_name }}
+      --project-directory {{ compose_staging_root }}/{{ compose_artifact_hash }}
+      --env-file {{ compose_runtime_env_path }}
+      --compose-file {{ compose_staging_root }}/{{ compose_artifact_hash }}/docker-compose.yml
+      --output /run/docker-compose-cutover-plan.json
+    executable: python
   become: true
   environment:
     HOME: "{{ compose_home_dir }}"
-  register: compose_cutover_dry_run
   changed_when: false
   check_mode: false
   no_log: true
 
-- name: Extract the exact proposed recreation set
+- name: Read the root-only pre-cutover action plan
+  ansible.builtin.slurp:
+    src: /run/docker-compose-cutover-plan.json
+  become: true
+  register: compose_cutover_plan_file
+  changed_when: false
+  check_mode: false
+  no_log: true
+
+- name: Parse the secret-free pre-cutover action plan
   ansible.builtin.set_fact:
+    compose_cutover_plan: "{{ compose_cutover_plan_file.content | b64decode | from_json }}"
     compose_cutover_recreate_services: >-
-      {{ ((compose_cutover_dry_run.stdout ~ '\n' ~ compose_cutover_dry_run.stderr)
-          | regex_findall('Container\\s+([a-z0-9-]+)\\s+Recreate') | unique | sort) }}
+      {{ (compose_cutover_plan_file.content | b64decode | from_json).recreate_services }}
     compose_cutover_forbidden_action_lines: >-
-      {{ ((compose_cutover_dry_run.stdout ~ '\n' ~ compose_cutover_dry_run.stderr)
-          | regex_findall('Container\\s+[a-z0-9-]+\\s+(?:Creating|Removing|Removed)')) }}
+      {{ (compose_cutover_plan_file.content | b64decode | from_json).forbidden_actions }}
+  no_log: true
+
+- name: Remove the root-only pre-cutover action plan
+  ansible.builtin.file:
+    path: /run/docker-compose-cutover-plan.json
+    state: absent
+  become: true
+  changed_when: false
   no_log: true
 
 - name: Report the secret-free proposed recreation set
@@ -189,39 +202,49 @@
       register: compose_cutover_converge
       no_log: true
 
-    - name: Verify no further Compose convergence is proposed
-      ansible.builtin.command:
-        argv:
-          - /usr/bin/docker
-          - compose
-          - --ansi
-          - never
-          - --dry-run
-          - --project-name
-          - "{{ compose_project_name }}"
-          - --project-directory
-          - "{{ compose_current_dir }}"
-          - --env-file
-          - "{{ compose_runtime_env_path }}"
-          - --file
-          - "{{ compose_current_dir }}/docker-compose.yml"
-          - create
-          - --no-build
-          - --pull
-          - never
+    - name: Produce the root-only post-cutover action plan
+      ansible.builtin.script:
+        cmd: >-
+          {{ role_path }}/../../../scripts/compose-action-plan.py
+          --project-name {{ compose_project_name }}
+          --project-directory {{ compose_current_dir }}
+          --env-file {{ compose_runtime_env_path }}
+          --compose-file {{ compose_current_dir }}/docker-compose.yml
+          --output /run/docker-compose-cutover-post-plan.json
+        executable: python
       become: true
       environment:
         HOME: "{{ compose_home_dir }}"
-      register: compose_cutover_post_dry_run
+      changed_when: false
+      no_log: true
+
+    - name: Read the root-only post-cutover action plan
+      ansible.builtin.slurp:
+        src: /run/docker-compose-cutover-post-plan.json
+      become: true
+      register: compose_cutover_post_plan_file
+      changed_when: false
+      no_log: true
+
+    - name: Parse the secret-free post-cutover action plan
+      ansible.builtin.set_fact:
+        compose_cutover_post_plan: >-
+          {{ compose_cutover_post_plan_file.content | b64decode | from_json }}
+      no_log: true
+
+    - name: Remove the root-only post-cutover action plan
+      ansible.builtin.file:
+        path: /run/docker-compose-cutover-post-plan.json
+        state: absent
+      become: true
       changed_when: false
       no_log: true
 
     - name: Require an idempotent post-cutover dry run
       ansible.builtin.assert:
         that:
-          - >-
-            ((compose_cutover_post_dry_run.stdout_lines + compose_cutover_post_dry_run.stderr_lines)
-            | select('search', ' Container .* (Create|Recreate|Remove) ') | list | length) == 0
+          - compose_cutover_post_plan.recreate_services | length == 0
+          - compose_cutover_post_plan.forbidden_actions | length == 0
         fail_msg: "Post-cutover dry run still proposes container convergence."
       no_log: true
 

--- a/ansible/roles/compose_rollback/tasks/main.yml
+++ b/ansible/roles/compose_rollback/tasks/main.yml
@@ -50,42 +50,55 @@
     fail_msg: "Deployed artifact identity differs from the separately reviewed rollback hash."
   no_log: true
 
-- name: Re-run the exact guarded legacy rollback dry run
-  ansible.builtin.command:
-    argv:
-      - /usr/bin/docker
-      - compose
-      - --ansi
-      - never
-      - --dry-run
-      - --project-name
-      - "{{ compose_project_name }}"
-      - --project-directory
-      - "{{ audit_compose_project_dir }}"
-      - --env-file
-      - "{{ audit_env_path }}"
-      - --file
-      - "{{ audit_compose_project_dir }}/docker-compose.yml"
-      - create
-      - --no-build
-      - --pull
-      - never
+- name: Remove any stale pre-rollback action plan
+  ansible.builtin.file:
+    path: /run/docker-compose-rollback-plan.json
+    state: absent
+  become: true
+  changed_when: false
+  no_log: true
+
+- name: Produce the root-only pre-rollback action plan
+  ansible.builtin.script:
+    cmd: >-
+      {{ role_path }}/../../../scripts/compose-action-plan.py
+      --project-name {{ compose_project_name }}
+      --project-directory {{ audit_compose_project_dir }}
+      --env-file {{ audit_env_path }}
+      --compose-file {{ audit_compose_project_dir }}/docker-compose.yml
+      --output /run/docker-compose-rollback-plan.json
+    executable: python
   become: true
   environment:
     HOME: "{{ compose_home_dir }}"
-  register: compose_rollback_dry_run
   changed_when: false
   check_mode: false
   no_log: true
 
-- name: Extract the exact proposed rollback recreation set
+- name: Read the root-only pre-rollback action plan
+  ansible.builtin.slurp:
+    src: /run/docker-compose-rollback-plan.json
+  become: true
+  register: compose_rollback_plan_file
+  changed_when: false
+  check_mode: false
+  no_log: true
+
+- name: Parse the secret-free pre-rollback action plan
   ansible.builtin.set_fact:
+    compose_rollback_plan: "{{ compose_rollback_plan_file.content | b64decode | from_json }}"
     compose_rollback_recreate_services: >-
-      {{ ((compose_rollback_dry_run.stdout ~ '\n' ~ compose_rollback_dry_run.stderr)
-          | regex_findall('Container\\s+([a-z0-9-]+)\\s+Recreate') | unique | sort) }}
+      {{ (compose_rollback_plan_file.content | b64decode | from_json).recreate_services }}
     compose_rollback_forbidden_action_lines: >-
-      {{ ((compose_rollback_dry_run.stdout ~ '\n' ~ compose_rollback_dry_run.stderr)
-          | regex_findall('Container\\s+[a-z0-9-]+\\s+(?:Creating|Removing|Removed)')) }}
+      {{ (compose_rollback_plan_file.content | b64decode | from_json).forbidden_actions }}
+  no_log: true
+
+- name: Remove the root-only pre-rollback action plan
+  ansible.builtin.file:
+    path: /run/docker-compose-rollback-plan.json
+    state: absent
+  become: true
+  changed_when: false
   no_log: true
 
 - name: Report the secret-free proposed rollback recreation set
@@ -137,39 +150,49 @@
         HOME: "{{ compose_home_dir }}"
       no_log: true
 
-    - name: Verify no further legacy Compose convergence is proposed
-      ansible.builtin.command:
-        argv:
-          - /usr/bin/docker
-          - compose
-          - --ansi
-          - never
-          - --dry-run
-          - --project-name
-          - "{{ compose_project_name }}"
-          - --project-directory
-          - "{{ audit_compose_project_dir }}"
-          - --env-file
-          - "{{ audit_env_path }}"
-          - --file
-          - "{{ audit_compose_project_dir }}/docker-compose.yml"
-          - create
-          - --no-build
-          - --pull
-          - never
+    - name: Produce the root-only post-rollback action plan
+      ansible.builtin.script:
+        cmd: >-
+          {{ role_path }}/../../../scripts/compose-action-plan.py
+          --project-name {{ compose_project_name }}
+          --project-directory {{ audit_compose_project_dir }}
+          --env-file {{ audit_env_path }}
+          --compose-file {{ audit_compose_project_dir }}/docker-compose.yml
+          --output /run/docker-compose-rollback-post-plan.json
+        executable: python
       become: true
       environment:
         HOME: "{{ compose_home_dir }}"
-      register: compose_rollback_post_dry_run
+      changed_when: false
+      no_log: true
+
+    - name: Read the root-only post-rollback action plan
+      ansible.builtin.slurp:
+        src: /run/docker-compose-rollback-post-plan.json
+      become: true
+      register: compose_rollback_post_plan_file
+      changed_when: false
+      no_log: true
+
+    - name: Parse the secret-free post-rollback action plan
+      ansible.builtin.set_fact:
+        compose_rollback_post_plan: >-
+          {{ compose_rollback_post_plan_file.content | b64decode | from_json }}
+      no_log: true
+
+    - name: Remove the root-only post-rollback action plan
+      ansible.builtin.file:
+        path: /run/docker-compose-rollback-post-plan.json
+        state: absent
+      become: true
       changed_when: false
       no_log: true
 
     - name: Require an idempotent post-rollback dry run
       ansible.builtin.assert:
         that:
-          - >-
-            ((compose_rollback_post_dry_run.stdout_lines + compose_rollback_post_dry_run.stderr_lines)
-            | select('search', ' Container .* (Create|Recreate|Remove) ') | list | length) == 0
+          - compose_rollback_post_plan.recreate_services | length == 0
+          - compose_rollback_post_plan.forbidden_actions | length == 0
         fail_msg: "Post-rollback dry run still proposes container convergence."
       no_log: true
 

--- a/scripts/compose-action-plan.py
+++ b/scripts/compose-action-plan.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Write a root-only, secret-free Docker Compose dry-run action plan."""
+
+from argparse import ArgumentParser
+import json
+from pathlib import Path
+import re
+import subprocess
+
+ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+ACTION_PATTERN = re.compile(
+    r"Container\s+([a-z0-9-]+)\s+"
+    r"(Creating|Created|Create|Recreated|Recreate|Removing|Removed|Remove|Starting|Started|Start|Stopping|Stopped|Stop)\b"
+)
+
+
+def main() -> None:
+    parser = ArgumentParser()
+    parser.add_argument("--project-name", required=True)
+    parser.add_argument("--project-directory", required=True, type=Path)
+    parser.add_argument("--env-file", required=True, type=Path)
+    parser.add_argument("--compose-file", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    result = subprocess.run(
+        [
+            "/usr/bin/docker",
+            "compose",
+            "--ansi",
+            "never",
+            "--dry-run",
+            "--project-name",
+            args.project_name,
+            "--project-directory",
+            str(args.project_directory),
+            "--env-file",
+            str(args.env_file),
+            "--file",
+            str(args.compose_file),
+            "create",
+            "--no-build",
+            "--pull",
+            "never",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    output = ANSI_PATTERN.sub("", result.stdout + result.stderr)
+    actions = [
+        {"service": service, "action": action}
+        for service, action in ACTION_PATTERN.findall(output)
+    ]
+    report = {
+        "recreate_services": sorted(
+            {entry["service"] for entry in actions if entry["action"] == "Recreate"}
+        ),
+        "forbidden_actions": [
+            entry
+            for entry in actions
+            if entry["action"] in {"Create", "Creating", "Created", "Remove", "Removing", "Removed"}
+        ],
+        "action_count": len(actions),
+    }
+    args.output.write_text(
+        json.dumps(report, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    args.output.chmod(0o600)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Parse cutover and rollback dry-run actions in a dedicated root-executed helper, transport only a root-only JSON action report under `no_log`, and remove each report before assertions.