### PR TITLE
fix: guard failed apply lock recovery

### DIFF
--- a/.github/workflows/clear-failed-apply-lock.yml
+++ b/.github/workflows/clear-failed-apply-lock.yml
@@ -1,0 +1,124 @@
+name: Clear an inspected failed production apply lock
+
+on:
+  workflow_dispatch:
+    inputs:
+      failed_run_id:
+        description: Exact failed GitHub Actions run ID
+        required: true
+        type: string
+      confirmation:
+        description: Enter clear-lock:<failed_run_id>
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ansible-production
+  cancel-in-progress: false
+
+env:
+  ANSIBLE_HOST_KEY_CHECKING: "true"
+  ANSIBLE_NOCOLOR: "1"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+jobs:
+  clear:
+    name: Clear only the inspected empty failed lock
+    if: vars.APPLY_LOCK_CLEAR_ENABLED == 'true' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: infrastructure-apply
+
+    steps:
+      - name: Check out the exact main commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Require typed failed-run confirmation
+        env:
+          FAILED_RUN_ID: ${{ inputs.failed_run_id }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ $FAILED_RUN_ID =~ ^[0-9]+$ ]]
+          [[ $CONFIRMATION == "clear-lock:$FAILED_RUN_ID" ]]
+
+      - name: Prepare the restricted apply controller
+        uses: ./.github/actions/ansible-controller
+        with:
+          oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TS_AUDIENCE }}
+          tags: tag:ci-apply
+          target-ip: 100.111.210.72
+          host-key-fingerprint: SHA256:2wHl3xsBkNYprqP99usjZdwj2Rytcc+MtJVErhowVYw
+          accept-subnet-routes: "false"
+
+      - name: Validate and review the exact lock clearance
+        id: plan
+        working-directory: ansible
+        shell: bash
+        run: |
+          set -euo pipefail
+          ansible-playbook -i inventory/production.yml \
+            --syntax-check playbooks/clear-failed-apply-lock.yml
+          plan_log="$RUNNER_TEMP/failed-lock-clear-plan.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/clear-failed-apply-lock.yml --check --diff | tee "$plan_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$plan_log" docker-host-production)
+          [[ $(jq -r '.changed' <<<"$recap") == 1 ]]
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Remove only the inspected empty failed lock
+        id: apply
+        working-directory: ansible
+        shell: bash
+        run: |
+          set -euo pipefail
+          apply_log="$RUNNER_TEMP/failed-lock-clear-apply.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/clear-failed-apply-lock.yml \
+            -e iac_lock_clear_confirmed=true | tee "$apply_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$apply_log" docker-host-production)
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Require lock absence after clearance
+        id: postcheck
+        working-directory: ansible
+        shell: bash
+        run: |
+          set -euo pipefail
+          post_log="$RUNNER_TEMP/failed-lock-clear-post.log"
+          ansible -i inventory/production.yml docker_host \
+            -b -m ansible.builtin.stat \
+            -a 'path=/var/lib/iac-ansible-production.lock get_checksum=false get_mime=false' \
+            | tee "$post_log"
+          grep -q '"exists": false' "$post_log"
+
+      - name: Summarize failed-lock clearance
+        env:
+          FAILED_RUN_ID: ${{ inputs.failed_run_id }}
+          PLAN_RECAP: ${{ steps.plan.outputs.recap }}
+          APPLY_RECAP: ${{ steps.apply.outputs.recap }}
+        shell: bash
+        run: |
+          {
+            echo "### Failed production apply lock clearance"
+            echo
+            echo "- Failed run: \`$FAILED_RUN_ID\`"
+            echo "- Reviewed plan: \`$PLAN_RECAP\`"
+            echo "- Clearance: \`$APPLY_RECAP\`"
+            echo "- Post-check: lock absent"
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/ansible/group_vars/docker_host.yml
+++ b/ansible/group_vars/docker_host.yml
@@ -46,6 +46,7 @@ age_binary_sha256: 2e305637f2a0555305e21c17fb74446acbb39b53135d43d4b744e50c28713
 age_keygen_binary_sha256: c56ef69834e18ca4d3b953117f4481522c35fb6862a5d2871685aa4685893664
 
 compose_project_name: docker-compose
+iac_apply_lock_path: /var/lib/iac-ansible-production.lock
 compose_home_dir: /home/docker
 compose_deployment_root: /srv/docker-compose
 compose_current_dir: /srv/docker-compose/current

--- a/ansible/playbooks/clear-failed-apply-lock.yml
+++ b/ansible/playbooks/clear-failed-apply-lock.yml
@@ -1,0 +1,60 @@
+---
+- name: Clear one separately inspected failed production apply lock
+  hosts: docker_host
+  gather_facts: false
+  any_errors_fatal: true
+  vars_files:
+    - "{{ playbook_dir }}/../group_vars/docker_host.yml"
+  tasks:
+    - name: Require explicit failed-lock clearance confirmation
+      ansible.builtin.assert:
+        that:
+          - ansible_check_mode or (iac_lock_clear_confirmed | default(false) | ansible.builtin.bool)
+        fail_msg: "Failed production lock clearance requires iac_lock_clear_confirmed=true."
+
+    - name: Inspect the failed production apply lock
+      ansible.builtin.stat:
+        path: "{{ item }}"
+        get_checksum: false
+        get_mime: false
+      become: true
+      register: iac_failed_lock_paths
+      loop:
+        - "{{ iac_apply_lock_path }}"
+        - "{{ iac_apply_lock_path }}/owner"
+
+    - name: Inspect failed production lock contents
+      ansible.builtin.find:
+        paths: "{{ iac_apply_lock_path }}"
+        hidden: true
+        recurse: false
+        file_type: any
+      become: true
+      register: iac_failed_lock_entries
+      when: iac_failed_lock_paths.results[0].stat.isdir | default(false)
+
+    - name: Require the inspected empty failed lock
+      ansible.builtin.assert:
+        that:
+          - iac_failed_lock_paths.results[0].stat.isdir | default(false)
+          - not (iac_failed_lock_paths.results[1].stat.exists | default(false))
+          - iac_failed_lock_entries.matched == 0
+        fail_msg: "Production lock is absent, has an owner record, or contains unreviewed entries."
+
+    - name: Report the failed-lock clearance plan
+      ansible.builtin.debug:
+        msg:
+          lock_path: "{{ iac_apply_lock_path }}"
+          owner_record: absent
+          entry_count: 0
+      changed_when: true
+      when: ansible_check_mode
+
+    - name: Remove only the inspected empty failed lock
+      ansible.builtin.command:
+        argv:
+          - /usr/bin/rmdir
+          - --
+          - "{{ iac_apply_lock_path }}"
+      become: true
+      when: not ansible_check_mode

--- a/ansible/playbooks/cutover-compose.yml
+++ b/ansible/playbooks/cutover-compose.yml
@@ -11,6 +11,7 @@
         name: apply_lock
       vars:
         iac_apply_lock_action: acquire
+        iac_apply_operation: compose-cutover
   roles:
     - role: compose_cutover
   post_tasks:
@@ -23,3 +24,4 @@
         name: apply_lock
       vars:
         iac_apply_lock_action: release
+        iac_apply_operation: compose-cutover

--- a/ansible/playbooks/rollback-compose.yml
+++ b/ansible/playbooks/rollback-compose.yml
@@ -11,6 +11,7 @@
         name: apply_lock
       vars:
         iac_apply_lock_action: acquire
+        iac_apply_operation: compose-rollback
   roles:
     - role: compose_rollback
   post_tasks:
@@ -23,3 +24,4 @@
         name: apply_lock
       vars:
         iac_apply_lock_action: release
+        iac_apply_operation: compose-rollback

--- a/ansible/roles/apply_lock/tasks/main.yml
+++ b/ansible/roles/apply_lock/tasks/main.yml
@@ -22,9 +22,9 @@
 - name: Record the production apply-lock owner
   ansible.builtin.copy:
     content: |
-      controller={{ ansible_user_id }}
-      tag={{ iac_apply_tag }}
-      started={{ ansible_date_time.iso8601 }}
+      controller={{ ansible_user | default('unknown') }}
+      operation={{ iac_apply_operation | default(iac_apply_tag | default('unspecified')) }}
+      started={{ ansible_facts['date_time']['iso8601'] }}
     dest: "{{ iac_apply_lock_path }}/owner"
     owner: root
     group: root


### PR DESCRIPTION
## Summary

- make production lock owner records work for dedicated Compose playbooks
- label cutover and rollback lock ownership explicitly
- add a disabled, typed-confirmation workflow that can remove only an inspected empty failed lock

Cutover run `30853421473` failed immediately after creating the lock because the owner-record variable was undefined. It performed no Docker command. Read-only audit `30853571318` subsequently reported `ok=45 changed=0 unreachable=0 failed=0`. The empty lock remains in place pending separate authorization.