### PR TITLE
feat: isolate staged compose environments

### DIFF
--- a/.github/workflows/compose-stage.yml
+++ b/.github/workflows/compose-stage.yml
@@ -116,25 +116,6 @@ jobs:
             playbooks/review-compose-stage.yml \
             -e "compose_artifact_hash=$ARTIFACT_HASH"
 
-      - name: Review the disabled initial cutover in check mode
-        id: cutoverplan
-        working-directory: ansible
-        env:
-          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          cutover_log="$RUNNER_TEMP/compose-cutover-plan.log"
-          ansible-playbook -i inventory/production.yml \
-            playbooks/cutover-compose.yml --check --diff \
-            -e "compose_artifact_hash=$ARTIFACT_HASH" | tee "$cutover_log"
-          recap=$(python ../.github/scripts/parse-ansible-recap.py \
-            "$cutover_log" docker-host-production)
-          [[ $(jq -r '.changed' <<<"$recap") == 1 ]]
-          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
-          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
-          echo "recap=$recap" >>"$GITHUB_OUTPUT"
-
       - name: Require zero staging changes after execution
         id: postcheck
         working-directory: ansible
@@ -177,7 +158,6 @@ jobs:
           ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
           PLAN_RECAP: ${{ steps.plan.outputs.recap }}
           APPLY_RECAP: ${{ steps.apply.outputs.recap }}
-          CUTOVER_PLAN_RECAP: ${{ steps.cutoverplan.outputs.recap }}
           POSTCHECK_RECAP: ${{ steps.postcheck.outputs.recap }}
           AUDIT_RECAP: ${{ steps.audit.outputs.recap }}
         shell: bash
@@ -189,7 +169,6 @@ jobs:
             echo "- Artifact SHA-256: \`$ARTIFACT_HASH\`"
             echo "- Check-mode recap: \`$PLAN_RECAP\`"
             echo "- Staging recap: \`$APPLY_RECAP\`"
-            echo "- Disabled cutover check-mode recap: \`$CUTOVER_PLAN_RECAP\`"
             echo "- Zero-change post-check: \`$POSTCHECK_RECAP\`"
             echo "- Full audit: \`$AUDIT_RECAP\`"
             echo

--- a/ansible/group_vars/docker_host.yml
+++ b/ansible/group_vars/docker_host.yml
@@ -53,6 +53,9 @@ compose_current_dir: /srv/docker-compose/current
 compose_staging_root: /srv/docker-compose/staging
 compose_previous_dir: /srv/docker-compose/previous
 compose_runtime_env_path: /etc/docker-compose/production.env
+compose_staged_env_root: /etc/docker-compose/staging
+compose_staged_env_path: "{{ compose_staged_env_root }}/{{ compose_artifact_hash }}.env"
+compose_previous_env_path: /etc/docker-compose/previous.env
 compose_age_identity_path: /etc/sops/age/keys.txt
 compose_deployed_hash_path: /var/lib/docker-compose/deployed.sha256
 compose_staged_inventory_path: /var/lib/docker-compose/staged-model.json

--- a/ansible/playbooks/review-compose-stage.yml
+++ b/ansible/playbooks/review-compose-stage.yml
@@ -26,7 +26,7 @@
               --runtime {{ compose_runtime_inventory_path }}
               --artifact-root {{ compose_staging_root }}/{{ compose_artifact_hash }}
               --project-directory {{ compose_staging_root }}/{{ compose_artifact_hash }}
-              --env-file {{ compose_runtime_env_path }}
+              --env-file {{ compose_staged_env_path }}
               --project-name {{ compose_project_name }}
               --output {{ compose_stage_review_path }}
             executable: python

--- a/ansible/roles/compose_stage/tasks/main.yml
+++ b/ansible/roles/compose_stage/tasks/main.yml
@@ -30,7 +30,7 @@
       - compose_stage_controller_hash.stdout == compose_artifact_hash
     fail_msg: "Controller artifact hash differs from the reviewed hash."
 
-- name: Inspect the final staging and runtime environment paths
+- name: Inspect the final artifact and candidate environment paths
   ansible.builtin.stat:
     path: "{{ item }}"
     get_checksum: false
@@ -39,13 +39,13 @@
   register: compose_stage_existing_paths
   loop:
     - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
-    - "{{ compose_runtime_env_path }}"
+    - "{{ compose_staged_env_path }}"
 
 - name: Report the expected staging changes in check mode
   ansible.builtin.debug:
     msg: >-
-      Artifact {{ compose_artifact_hash }} will be installed under the root-owned staging tree and
-      the SOPS environment will be decrypted to the root-only runtime path.
+      Artifact {{ compose_artifact_hash }} and its root-only candidate environment will be installed
+      under inactive hash-addressed staging paths.
   changed_when: >-
     not compose_stage_existing_paths.results[0].stat.exists or
     not compose_stage_existing_paths.results[1].stat.exists
@@ -72,6 +72,8 @@
         - path: "{{ compose_previous_dir }}"
           mode: "0755"
         - path: /etc/docker-compose
+          mode: "0700"
+        - path: "{{ compose_staged_env_root }}"
           mode: "0700"
         - path: /var/lib/docker-compose
           mode: "0700"
@@ -183,10 +185,10 @@
       become: true
       no_log: true
 
-    - name: Atomically install the root-only runtime environment
+    - name: Atomically install the root-only candidate environment
       ansible.builtin.copy:
         src: "{{ compose_stage_decrypt_workspace.path }}/production.env"
-        dest: "{{ compose_runtime_env_path }}"
+        dest: "{{ compose_staged_env_path }}"
         remote_src: true
         owner: root
         group: root
@@ -205,7 +207,7 @@
           - --project-directory
           - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
           - --env-file
-          - "{{ compose_runtime_env_path }}"
+          - "{{ compose_staged_env_path }}"
           - --file
           - "{{ compose_staging_root }}/{{ compose_artifact_hash }}/docker-compose.yml"
           - config
@@ -227,7 +229,7 @@
           - --project-directory
           - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
           - --env-file
-          - "{{ compose_runtime_env_path }}"
+          - "{{ compose_staged_env_path }}"
           - --project-name
           - "{{ compose_project_name }}"
           - --bind-root-override
@@ -280,7 +282,7 @@
           - --project-directory
           - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
           - --env-file
-          - "{{ compose_runtime_env_path }}"
+          - "{{ compose_staged_env_path }}"
           - --file
           - "{{ compose_staging_root }}/{{ compose_artifact_hash }}/docker-compose.yml"
           - create

--- a/docs/compose-deployment.md
+++ b/docs/compose-deployment.md
@@ -21,6 +21,7 @@ The canonical artifact hash is SHA-256 over a version marker followed by each so
 /srv/docker-compose/staging/<artifact-sha256>
 /srv/docker-compose/previous
 /etc/docker-compose/production.env
+/etc/docker-compose/staging/<artifact-sha256>.env
 /var/lib/docker-compose/deployed.sha256
 ```
 
@@ -39,8 +40,8 @@ The existing `/home/docker/Projects/docker-compose` checkout and `.env` remain u
 5. recomputes the hash before atomically publishing `staging/<hash>`;
 6. decrypts SOPS only on the host through `/etc/sops/age/keys.txt`;
 7. restores the non-secret dotenv layout in a root-only temporary directory;
-8. atomically installs `/etc/docker-compose/production.env` as `root:root 0600` with `no_log: true`;
-9. validates with explicit project name, immutable staging project directory, environment file, and `docker compose config --quiet`;
+8. atomically installs an inactive `/etc/docker-compose/staging/<artifact-sha256>.env` as `root:root 0600` with `no_log: true`;
+9. validates with explicit project name, immutable staging project directory, candidate environment file, and `docker compose config --quiet`;
 10. writes root-owned secret-free desired and runtime inventories;
 11. runs `docker compose --dry-run create --no-build --pull never`; and
 12. requires a zero-change staging post-check and complete read-only audit.
@@ -75,7 +76,7 @@ The backup services now declare `/etc/docker-compose/production.env:/backup/.env
 
 ## Cutover boundary
 
-Phase 3 may populate staging, the empty stable directories, and the inactive root-only environment file. It must not synchronize an artifact into `current`, change runtime Compose labels, pull images, or converge containers. Those actions remain Phase 4 maintenance-window work.
+Staging may populate hash-addressed artifacts and inactive root-only candidate environment files. It never overwrites the active `/etc/docker-compose/production.env`, synchronizes an artifact into `current`, changes runtime Compose labels, pulls images, or converges containers.
 
 The Phase 4 implementation is fail-closed and inactive by default. `.github/workflows/compose-cutover.yml` requires all of the following before its job can run:
 


### PR DESCRIPTION
## Summary

- decrypt each candidate into a root-only hash-addressed staging environment
- validate and dry-run candidates without overwriting the active production environment
- retire the completed one-time cutover check from the reusable staging workflow

This workflow remains non-convergent and performs no Docker mutation.