### PR TITLE
feat: automate protected compose deploys

### DIFF
--- a/.github/workflows/compose-deploy.yml
+++ b/.github/workflows/compose-deploy.yml
@@ -1,0 +1,298 @@
+name: Compose protected deployment
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/actions/ansible-controller/**
+      - .github/requirements-ansible-controller.lock
+      - .github/scripts/**
+      - .github/workflows/compose-deploy.yml
+      - .sops.yaml
+      - ansible/group_vars/docker_host.yml
+      - ansible/inventory/production.yml
+      - ansible/playbooks/deploy-compose.yml
+      - ansible/playbooks/stage-compose.yml
+      - ansible/roles/apply_lock/**
+      - ansible/roles/compose_deploy/**
+      - ansible/roles/compose_stage/**
+      - ansible/roles/health/**
+      - docker-compose.yml
+      - scripts/check-sops-env.py
+      - scripts/compose-action-plan.py
+      - scripts/compose-artifact.py
+      - scripts/compose-deployment-diff.py
+      - scripts/compose-model-inventory.py
+      - scripts/restore-dotenv-layout.py
+      - secrets/**
+      - services/*.yml
+      - services/data/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ansible-production
+  cancel-in-progress: false
+
+env:
+  ANSIBLE_HOST_KEY_CHECKING: "true"
+  ANSIBLE_NOCOLOR: "1"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+jobs:
+  plan:
+    name: Stage and plan exact Compose artifact
+    if: vars.COMPOSE_AUTO_PLAN_ENABLED == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    environment: infrastructure-apply
+    outputs:
+      artifact_hash: ${{ steps.artifact.outputs.hash }}
+      has_changes: ${{ steps.plan.outputs.has_changes }}
+      plan_hash: ${{ steps.plan.outputs.plan_hash }}
+      plan_recap: ${{ steps.plan.outputs.recap }}
+
+    steps:
+      - name: Check out the exact candidate commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Build and identify the exact controller artifact
+        id: artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_root="$RUNNER_TEMP/compose-artifact"
+          desired_hash=$(python3 scripts/compose-artifact.py hash)
+          copied_hash=$(python3 scripts/compose-artifact.py copy "$artifact_root")
+          [[ $copied_hash == "$desired_hash" ]]
+          echo "root=$artifact_root" >>"$GITHUB_OUTPUT"
+          echo "hash=$desired_hash" >>"$GITHUB_OUTPUT"
+
+      - name: Prepare the restricted apply controller
+        uses: ./.github/actions/ansible-controller
+        with:
+          oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TS_AUDIENCE }}
+          tags: tag:ci-apply
+          target-ip: 100.111.210.72
+          host-key-fingerprint: SHA256:2wHl3xsBkNYprqP99usjZdwj2Rytcc+MtJVErhowVYw
+          accept-subnet-routes: "false"
+
+      - name: Validate inventory, connectivity, and deployment syntax
+        working-directory: ansible
+        shell: bash
+        run: |
+          set -euo pipefail
+          ansible-inventory -i inventory/production.yml --graph
+          ansible-playbook -i inventory/production.yml --syntax-check playbooks/stage-compose.yml
+          ansible-playbook -i inventory/production.yml --syntax-check playbooks/deploy-compose.yml
+          ansible -i inventory/production.yml docker_host -m ansible.builtin.ping
+
+      - name: Stage the exact inactive candidate
+        working-directory: ansible
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+          ARTIFACT_ROOT: ${{ steps.artifact.outputs.root }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ansible-playbook -i inventory/production.yml \
+            playbooks/stage-compose.yml \
+            -e "compose_artifact_hash=$ARTIFACT_HASH" \
+            -e "compose_artifact_controller_dir=$ARTIFACT_ROOT" \
+            -e compose_stage_confirmed=true
+
+      - name: Display the complete secret-free candidate review
+        working-directory: ansible
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ansible-playbook -i inventory/production.yml \
+            playbooks/review-compose-stage.yml \
+            -e "compose_artifact_hash=$ARTIFACT_HASH"
+
+      - name: Produce the exact protected deployment plan
+        id: plan
+        working-directory: ansible
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          plan_log="$RUNNER_TEMP/compose-deploy-plan.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/deploy-compose.yml --check --diff \
+            -e "compose_artifact_hash=$ARTIFACT_HASH" | tee "$plan_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$plan_log" docker-host-production)
+          changed=$(jq -r '.changed' <<<"$recap")
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          if [[ $changed == 0 ]]; then has_changes=false; else has_changes=true; fi
+          plan_hash=$(sha256sum "$plan_log" | awk '{print $1}')
+          echo "has_changes=$has_changes" >>"$GITHUB_OUTPUT"
+          echo "plan_hash=$plan_hash" >>"$GITHUB_OUTPUT"
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Summarize the protected Compose plan
+        env:
+          ARTIFACT_HASH: ${{ steps.artifact.outputs.hash }}
+          PLAN_HASH: ${{ steps.plan.outputs.plan_hash }}
+          PLAN_RECAP: ${{ steps.plan.outputs.recap }}
+        shell: bash
+        run: |
+          {
+            echo "### Compose deployment plan"
+            echo
+            echo "- Commit: \`$GITHUB_SHA\`"
+            echo "- Artifact SHA-256: \`$ARTIFACT_HASH\`"
+            echo "- Plan SHA-256: \`$PLAN_HASH\`"
+            echo "- Recap: \`$PLAN_RECAP\`"
+            echo
+            echo "This job staged only inactive inputs and did not pull images or converge containers."
+          } >>"$GITHUB_STEP_SUMMARY"
+
+  apply:
+    name: Apply the merged Compose plan
+    needs: plan
+    if: >-
+      github.event_name == 'push' &&
+      needs.plan.outputs.has_changes == 'true' &&
+      vars.COMPOSE_AUTO_APPLY_ENABLED == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    environment: infrastructure-apply
+
+    steps:
+      - name: Check out the exact planned commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Require the planned commit at the tip of main
+        env:
+          EXPECTED_ARTIFACT_HASH: ${{ needs.plan.outputs.artifact_hash }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ $(git rev-parse HEAD) == "$GITHUB_SHA" ]]
+          git fetch --quiet --no-tags origin refs/heads/main
+          [[ $(git rev-parse FETCH_HEAD) == "$GITHUB_SHA" ]]
+          [[ $(python3 scripts/compose-artifact.py hash) == "$EXPECTED_ARTIFACT_HASH" ]]
+
+      - name: Prepare the restricted apply controller
+        uses: ./.github/actions/ansible-controller
+        with:
+          oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TS_AUDIENCE }}
+          tags: tag:ci-apply
+          target-ip: 100.111.210.72
+          host-key-fingerprint: SHA256:2wHl3xsBkNYprqP99usjZdwj2Rytcc+MtJVErhowVYw
+          accept-subnet-routes: "false"
+
+      - name: Revalidate the exact merged deployment plan
+        working-directory: ansible
+        env:
+          ARTIFACT_HASH: ${{ needs.plan.outputs.artifact_hash }}
+          EXPECTED_PLAN_HASH: ${{ needs.plan.outputs.plan_hash }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          replan_log="$RUNNER_TEMP/compose-deploy-replan.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/deploy-compose.yml --check --diff \
+            -e "compose_artifact_hash=$ARTIFACT_HASH" | tee "$replan_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$replan_log" docker-host-production)
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          [[ $(sha256sum "$replan_log" | awk '{print $1}') == "$EXPECTED_PLAN_HASH" ]]
+
+      - name: Deploy the exact approved Compose artifact
+        id: apply
+        working-directory: ansible
+        env:
+          ARTIFACT_HASH: ${{ needs.plan.outputs.artifact_hash }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --quiet --no-tags origin refs/heads/main
+          [[ $(git rev-parse FETCH_HEAD) == "$GITHUB_SHA" ]]
+          apply_log="$RUNNER_TEMP/compose-deploy-apply.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/deploy-compose.yml \
+            -e "compose_artifact_hash=$ARTIFACT_HASH" \
+            -e compose_deploy_confirmed=true | tee "$apply_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$apply_log" docker-host-production)
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Require zero deployment changes after the apply attempt
+        id: postcheck
+        if: always() && (steps.apply.outcome == 'success' || steps.apply.outcome == 'failure')
+        working-directory: ansible
+        env:
+          ARTIFACT_HASH: ${{ needs.plan.outputs.artifact_hash }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          post_log="$RUNNER_TEMP/compose-deploy-postcheck.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/deploy-compose.yml --check --diff \
+            -e "compose_artifact_hash=$ARTIFACT_HASH" | tee "$post_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$post_log" docker-host-production)
+          [[ $(jq -r '.changed' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Require a zero-change full audit after the apply attempt
+        id: audit
+        if: always() && (steps.apply.outcome == 'success' || steps.apply.outcome == 'failure')
+        working-directory: ansible
+        shell: bash
+        run: |
+          set -euo pipefail
+          audit_log="$RUNNER_TEMP/compose-deploy-audit.log"
+          ansible-playbook -i inventory/production.yml \
+            playbooks/audit.yml --check --diff | tee "$audit_log"
+          recap=$(python ../.github/scripts/parse-ansible-recap.py \
+            "$audit_log" docker-host-production)
+          [[ $(jq -r '.changed' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
+          [[ $(jq -r '.failed' <<<"$recap") == 0 ]]
+          echo "recap=$recap" >>"$GITHUB_OUTPUT"
+
+      - name: Summarize the Compose apply attempt
+        if: always() && (steps.apply.outcome == 'success' || steps.apply.outcome == 'failure')
+        env:
+          ARTIFACT_HASH: ${{ needs.plan.outputs.artifact_hash }}
+          PLAN_HASH: ${{ needs.plan.outputs.plan_hash }}
+          APPLY_RECAP: ${{ steps.apply.outputs.recap }}
+          POSTCHECK_RECAP: ${{ steps.postcheck.outputs.recap }}
+          AUDIT_RECAP: ${{ steps.audit.outputs.recap }}
+        shell: bash
+        run: |
+          {
+            echo "### Compose apply verification"
+            echo
+            echo "- Commit: \`$GITHUB_SHA\`"
+            echo "- Artifact SHA-256: \`$ARTIFACT_HASH\`"
+            echo "- Approved plan SHA-256: \`$PLAN_HASH\`"
+            echo "- Apply outcome: \`${{ steps.apply.outcome }}\`"
+            echo "- Apply recap: \`${APPLY_RECAP:-unavailable}\`"
+            echo "- Post-check: \`${POSTCHECK_RECAP:-unavailable}\`"
+            echo "- Full audit: \`${AUDIT_RECAP:-unavailable}\`"
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/ansible/playbooks/deploy-compose.yml
+++ b/ansible/playbooks/deploy-compose.yml
@@ -1,0 +1,27 @@
+---
+- name: Deploy one exact staged Compose artifact
+  hosts: docker_host
+  gather_facts: true
+  any_errors_fatal: true
+  vars_files:
+    - "{{ playbook_dir }}/../group_vars/docker_host.yml"
+  pre_tasks:
+    - name: Acquire the host-side production apply lock
+      ansible.builtin.import_role:
+        name: apply_lock
+      vars:
+        iac_apply_lock_action: acquire
+        iac_apply_operation: compose-deploy
+  roles:
+    - role: compose_deploy
+  post_tasks:
+    - name: Verify the complete running service baseline after deployment
+      ansible.builtin.import_role:
+        name: health
+
+    - name: Release the host-side production apply lock after successful verification
+      ansible.builtin.import_role:
+        name: apply_lock
+      vars:
+        iac_apply_lock_action: release
+        iac_apply_operation: compose-deploy

--- a/ansible/roles/compose_deploy/tasks/main.yml
+++ b/ansible/roles/compose_deploy/tasks/main.yml
@@ -1,0 +1,375 @@
+---
+- name: Validate the Compose deployment contract
+  ansible.builtin.assert:
+    that:
+      - compose_artifact_hash is match('^[0-9a-f]{64}$')
+      - ansible_check_mode or (compose_deploy_confirmed | default(false) | ansible.builtin.bool)
+    fail_msg: >-
+      Compose deployment requires the exact staged artifact hash and compose_deploy_confirmed=true
+      outside check mode.
+
+- name: Inspect candidate and active deployment inputs
+  ansible.builtin.stat:
+    path: "{{ item }}"
+    get_checksum: false
+    get_mime: false
+  become: true
+  register: compose_deploy_paths
+  loop:
+    - "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
+    - "{{ compose_staged_env_path }}"
+    - "{{ compose_current_dir }}"
+    - "{{ compose_runtime_env_path }}"
+    - "{{ compose_deployed_hash_path }}"
+    - "{{ compose_staged_inventory_path }}"
+    - "{{ compose_runtime_inventory_path }}"
+
+- name: Require complete root-owned candidate and active inputs
+  ansible.builtin.assert:
+    that:
+      - compose_deploy_paths.results[0].stat.isdir | default(false)
+      - compose_deploy_paths.results[1].stat.isreg | default(false)
+      - compose_deploy_paths.results[1].stat.pw_name == 'root'
+      - compose_deploy_paths.results[1].stat.mode == '0600'
+      - compose_deploy_paths.results[2].stat.isdir | default(false)
+      - compose_deploy_paths.results[3].stat.isreg | default(false)
+      - compose_deploy_paths.results[3].stat.pw_name == 'root'
+      - compose_deploy_paths.results[3].stat.mode == '0600'
+      - compose_deploy_paths.results[4].stat.isreg | default(false)
+      - compose_deploy_paths.results[5].stat.isreg | default(false)
+      - compose_deploy_paths.results[6].stat.isreg | default(false)
+    fail_msg: "Candidate staging, active deployment, environment, hash, or inventory input is missing."
+
+- name: Recompute candidate and current artifact identities
+  ansible.builtin.command:
+    argv:
+      - python
+      - "{{ item.root }}/scripts/compose-artifact.py"
+      - --root
+      - "{{ item.root }}"
+      - --no-git
+      - hash
+  become: true
+  register: compose_deploy_artifact_hashes
+  changed_when: false
+  check_mode: false
+  loop:
+    - root: "{{ compose_staging_root }}/{{ compose_artifact_hash }}"
+    - root: "{{ compose_current_dir }}"
+
+- name: Read the deployed artifact identity without displaying it
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/cat
+      - "{{ compose_deployed_hash_path }}"
+  become: true
+  register: compose_deploy_recorded_hash
+  changed_when: false
+  check_mode: false
+  no_log: true
+
+- name: Require exact candidate and active artifact identities
+  ansible.builtin.assert:
+    that:
+      - compose_deploy_artifact_hashes.results[0].stdout == compose_artifact_hash
+      - compose_deploy_artifact_hashes.results[1].stdout == compose_deploy_recorded_hash.stdout
+    fail_msg: "Candidate hash or active current/deployed identity differs from the reviewed state."
+  no_log: true
+
+- name: Remove stale root-only deployment plan files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  become: true
+  changed_when: false
+  no_log: true
+  loop:
+    - /run/docker-compose-deploy-actions.json
+    - /run/docker-compose-deploy-plan.json
+
+- name: Produce the root-only candidate action plan
+  ansible.builtin.script:
+    cmd: >-
+      {{ role_path }}/../../../scripts/compose-action-plan.py
+      --project-name {{ compose_project_name }}
+      --project-directory {{ compose_staging_root }}/{{ compose_artifact_hash }}
+      --env-file {{ compose_staged_env_path }}
+      --compose-file {{ compose_staging_root }}/{{ compose_artifact_hash }}/docker-compose.yml
+      --output /run/docker-compose-deploy-actions.json
+    executable: python
+  become: true
+  environment:
+    HOME: "{{ compose_home_dir }}"
+  changed_when: false
+  check_mode: false
+  no_log: true
+
+- name: Produce the root-only combined deployment plan
+  ansible.builtin.script:
+    cmd: >-
+      {{ role_path }}/../../../scripts/compose-deployment-diff.py
+      --desired {{ compose_staged_inventory_path }}
+      --runtime {{ compose_runtime_inventory_path }}
+      --actions /run/docker-compose-deploy-actions.json
+      --candidate-root {{ compose_staging_root }}/{{ compose_artifact_hash }}
+      --current-root {{ compose_current_dir }}
+      --candidate-hash {{ compose_artifact_hash }}
+      --deployed-hash {{ compose_deploy_recorded_hash.stdout }}
+      --output /run/docker-compose-deploy-plan.json
+    executable: python
+  become: true
+  changed_when: false
+  check_mode: false
+  no_log: true
+
+- name: Read the root-only combined deployment plan
+  ansible.builtin.slurp:
+    src: /run/docker-compose-deploy-plan.json
+  become: true
+  register: compose_deploy_plan_file
+  changed_when: false
+  check_mode: false
+  no_log: true
+
+- name: Parse the secret-free deployment plan
+  ansible.builtin.set_fact:
+    compose_deploy_plan: "{{ compose_deploy_plan_file.content | b64decode | from_json }}"
+  no_log: true
+
+- name: Remove root-only deployment plan files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  become: true
+  changed_when: false
+  no_log: true
+  loop:
+    - /run/docker-compose-deploy-actions.json
+    - /run/docker-compose-deploy-plan.json
+
+- name: Display only the secret-free deployment plan
+  ansible.builtin.debug:
+    var: compose_deploy_plan
+
+- name: Require a deployment with no service-set or untracked data-file changes
+  ansible.builtin.assert:
+    that:
+      - compose_deploy_plan.missing_runtime_services | length == 0
+      - compose_deploy_plan.unexpected_runtime_services | length == 0
+      - compose_deploy_plan.forbidden_actions | length == 0
+      - compose_deploy_plan.manual_only_paths | length == 0
+    fail_msg: >-
+      Automatic deployment refuses service additions/removals, forbidden Compose actions, and
+      services/data changes that require an explicit service restart decision.
+
+- name: Report the check-mode deployment boundary
+  ansible.builtin.debug:
+    msg:
+      candidate_hash: "{{ compose_artifact_hash }}"
+      recreate_services: "{{ compose_deploy_plan.recreate_services }}"
+      image_services: "{{ compose_deploy_plan.image_services }}"
+      stateful_recreate_services: "{{ compose_deploy_plan.stateful_recreate_services }}"
+  changed_when: compose_deploy_plan.has_changes
+  when: ansible_check_mode
+
+- name: Deploy the exact staged Compose artifact
+  when:
+    - not ansible_check_mode
+    - compose_deploy_plan.has_changes
+  block:
+    - name: Pull only changed service images without starting containers
+      ansible.builtin.command:
+        argv: >-
+          {{ ['/usr/bin/docker', 'compose', '--project-name', compose_project_name,
+              '--project-directory', compose_staging_root ~ '/' ~ compose_artifact_hash,
+              '--env-file', compose_staged_env_path,
+              '--file', compose_staging_root ~ '/' ~ compose_artifact_hash ~ '/docker-compose.yml',
+              'pull', '--policy', 'always', '--ignore-buildable'] + compose_deploy_plan.image_services }}
+      become: true
+      environment:
+        HOME: "{{ compose_home_dir }}"
+      no_log: true
+      when: compose_deploy_plan.image_services | length > 0
+
+    - name: Create an incoming current artifact directory
+      ansible.builtin.tempfile:
+        state: directory
+        path: "{{ compose_deployment_root }}"
+        prefix: .deploy-
+      become: true
+      register: compose_deploy_incoming
+
+    - name: Copy the immutable candidate into the incoming current directory
+      ansible.builtin.copy:
+        src: "{{ compose_staging_root }}/{{ compose_artifact_hash }}/"
+        dest: "{{ compose_deploy_incoming.path }}/"
+        remote_src: true
+        owner: root
+        group: root
+        mode: preserve
+        directory_mode: "0755"
+      become: true
+
+    - name: Recompute the incoming current artifact identity
+      ansible.builtin.command:
+        argv:
+          - python
+          - "{{ compose_deploy_incoming.path }}/scripts/compose-artifact.py"
+          - --root
+          - "{{ compose_deploy_incoming.path }}"
+          - --no-git
+          - hash
+      become: true
+      register: compose_deploy_incoming_hash
+      changed_when: false
+
+    - name: Require the incoming current artifact identity
+      ansible.builtin.assert:
+        that:
+          - compose_deploy_incoming_hash.stdout == compose_artifact_hash
+        fail_msg: "Incoming current artifact differs from the approved candidate."
+
+    - name: Remove the older tracked previous artifact
+      ansible.builtin.file:
+        path: "{{ compose_previous_dir }}"
+        state: absent
+      become: true
+
+    - name: Preserve the active environment for rollback
+      ansible.builtin.copy:
+        src: "{{ compose_runtime_env_path }}"
+        dest: "{{ compose_previous_env_path }}"
+        remote_src: true
+        owner: root
+        group: root
+        mode: "0600"
+      become: true
+      no_log: true
+
+    - name: Atomically rotate current and previous artifacts before Docker convergence
+      block:
+        - name: Move current to the tracked previous artifact
+          ansible.builtin.command:
+            argv:
+              - /usr/bin/mv
+              - --
+              - "{{ compose_current_dir }}"
+              - "{{ compose_previous_dir }}"
+          become: true
+
+        - name: Publish the incoming artifact as current
+          ansible.builtin.command:
+            argv:
+              - /usr/bin/mv
+              - --
+              - "{{ compose_deploy_incoming.path }}"
+              - "{{ compose_current_dir }}"
+          become: true
+      rescue:
+        - name: Inspect current after interrupted pre-Docker artifact rotation
+          ansible.builtin.stat:
+            path: "{{ compose_current_dir }}"
+          become: true
+          register: compose_deploy_rescue_current
+
+        - name: Restore previous as current only before Docker convergence
+          ansible.builtin.command:
+            argv:
+              - /usr/bin/mv
+              - --
+              - "{{ compose_previous_dir }}"
+              - "{{ compose_current_dir }}"
+          become: true
+          when: not (compose_deploy_rescue_current.stat.exists | default(false))
+
+        - name: Stop after pre-Docker artifact rotation failure
+          ansible.builtin.fail:
+            msg: "Artifact publication failed before Docker convergence; current was restored when absent."
+
+    - name: Activate the reviewed root-only candidate environment
+      ansible.builtin.copy:
+        src: "{{ compose_staged_env_path }}"
+        dest: "{{ compose_runtime_env_path }}"
+        remote_src: true
+        owner: root
+        group: root
+        mode: "0600"
+      become: true
+      no_log: true
+
+    - name: Converge the reviewed project without builds, removal, or orphan removal
+      ansible.builtin.command:
+        argv:
+          - /usr/bin/docker
+          - compose
+          - --project-name
+          - "{{ compose_project_name }}"
+          - --project-directory
+          - "{{ compose_current_dir }}"
+          - --env-file
+          - "{{ compose_runtime_env_path }}"
+          - --file
+          - "{{ compose_current_dir }}/docker-compose.yml"
+          - up
+          - --detach
+          - --no-build
+          - --pull
+          - never
+      become: true
+      environment:
+        HOME: "{{ compose_home_dir }}"
+      no_log: true
+
+    - name: Produce the root-only post-deployment action plan
+      ansible.builtin.script:
+        cmd: >-
+          {{ role_path }}/../../../scripts/compose-action-plan.py
+          --project-name {{ compose_project_name }}
+          --project-directory {{ compose_current_dir }}
+          --env-file {{ compose_runtime_env_path }}
+          --compose-file {{ compose_current_dir }}/docker-compose.yml
+          --output /run/docker-compose-deploy-post.json
+        executable: python
+      become: true
+      environment:
+        HOME: "{{ compose_home_dir }}"
+      changed_when: false
+      no_log: true
+
+    - name: Read the root-only post-deployment action plan
+      ansible.builtin.slurp:
+        src: /run/docker-compose-deploy-post.json
+      become: true
+      register: compose_deploy_post_file
+      changed_when: false
+      no_log: true
+
+    - name: Parse the secret-free post-deployment action plan
+      ansible.builtin.set_fact:
+        compose_deploy_post_plan: "{{ compose_deploy_post_file.content | b64decode | from_json }}"
+      no_log: true
+
+    - name: Remove the root-only post-deployment action plan
+      ansible.builtin.file:
+        path: /run/docker-compose-deploy-post.json
+        state: absent
+      become: true
+      changed_when: false
+      no_log: true
+
+    - name: Require an idempotent post-deployment action plan
+      ansible.builtin.assert:
+        that:
+          - compose_deploy_post_plan.recreate_services | length == 0
+          - compose_deploy_post_plan.forbidden_actions | length == 0
+        fail_msg: "Post-deployment Compose plan still proposes convergence."
+      no_log: true
+
+    - name: Record the deployed artifact identity atomically
+      ansible.builtin.copy:
+        content: "{{ compose_artifact_hash }}\n"
+        dest: "{{ compose_deployed_hash_path }}"
+        owner: root
+        group: root
+        mode: "0600"
+      become: true

--- a/docs/compose-deployment.md
+++ b/docs/compose-deployment.md
@@ -104,3 +104,11 @@ Authorized retry [`30854028095`](https://github.com/soodoh/docker-compose/action
 - post-cutover audit: `ok=45 changed=0 unreachable=0 failed=0`.
 
 All temporary enable variables were removed after use. Cutover, failed-lock clearance, and rollback are disabled. `/srv/docker-compose/current` and `/etc/docker-compose/production.env` are now active, while the legacy checkout and `.env` remain untouched rollback inputs.
+
+## Protected ongoing deployment
+
+`.github/workflows/compose-deploy.yml` is the post-cutover deployment path. Pull requests remain secret-free and unprivileged: `compose-artifact.yml` validates and hashes the exact candidate without contacting the host. After a reviewed merge, the trusted `main` workflow may use the protected apply identity to stage the exact artifact and its isolated candidate environment, display the restricted model differences, and produce a hash-locked check-mode deployment plan.
+
+The apply job is independently disabled unless `COMPOSE_AUTO_APPLY_ENABLED=true`. A changed merged plan must still match the current `main` tip and reproduce the complete plan hash. Deployment refuses service additions/removals, Docker create/remove actions, and `services/data/**` changes that lack an explicit restart decision. It pulls only services whose reviewed image reference changed, preserves current as `previous` plus a root-only previous environment, rotates the hash-verified artifact before Docker convergence, and runs Compose without builds or orphan removal. No image or volume pruning occurs.
+
+Every apply attempt retains the production lock on failure. Success requires an idempotent post-deployment Compose action plan, all 41 services running, healthy Gluetun and Seerr, a zero-change deployment post-check, and a zero-change complete audit. There is no automatic stateful rollback; the tracked previous artifact and environment are recovery inputs for a separately reviewed rollback.

--- a/scripts/compose-deployment-diff.py
+++ b/scripts/compose-deployment-diff.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Combine secret-free Compose inventories and dry-run actions into a deploy plan."""
+
+from argparse import ArgumentParser
+import json
+from pathlib import Path
+
+
+def load_object(path: Path) -> dict[str, object]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise SystemExit("plan input must be a JSON object")
+    return value
+
+
+def main() -> None:
+    parser = ArgumentParser()
+    parser.add_argument("--desired", required=True, type=Path)
+    parser.add_argument("--runtime", required=True, type=Path)
+    parser.add_argument("--actions", required=True, type=Path)
+    parser.add_argument("--candidate-root", required=True, type=Path)
+    parser.add_argument("--current-root", required=True, type=Path)
+    parser.add_argument("--candidate-hash", required=True)
+    parser.add_argument("--deployed-hash", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    desired = load_object(args.desired)
+    runtime = load_object(args.runtime)
+    actions = load_object(args.actions)
+    if desired.get("kind") != "desired" or runtime.get("kind") != "runtime":
+        raise SystemExit("inventory kinds are invalid")
+    if desired.get("project_name") != runtime.get("project_name"):
+        raise SystemExit("inventory project names differ")
+    desired_services = desired.get("services")
+    runtime_services = runtime.get("services")
+    recreate_services = actions.get("recreate_services")
+    forbidden_actions = actions.get("forbidden_actions")
+    if not isinstance(desired_services, dict) or not isinstance(runtime_services, dict):
+        raise SystemExit("inventory services are invalid")
+    if not isinstance(recreate_services, list) or not isinstance(forbidden_actions, list):
+        raise SystemExit("action plan is invalid")
+
+    desired_names = set(desired_services)
+    runtime_names = set(runtime_services)
+    image_services = []
+    stateful_services = []
+    for service_name in sorted(desired_names & runtime_names):
+        desired_service = desired_services[service_name]
+        runtime_service = runtime_services[service_name]
+        if not isinstance(desired_service, dict) or not isinstance(runtime_service, dict):
+            raise SystemExit("service inventory entry is invalid")
+        if desired_service.get("image") != runtime_service.get("image"):
+            image_services.append(service_name)
+        volumes = desired_service.get("volumes")
+        if service_name in recreate_services and isinstance(volumes, list) and volumes:
+            stateful_services.append(service_name)
+
+    candidate_paths = {
+        path.relative_to(args.candidate_root).as_posix(): path.read_bytes()
+        for path in args.candidate_root.rglob("*")
+        if path.is_file()
+    }
+    current_paths = {
+        path.relative_to(args.current_root).as_posix(): path.read_bytes()
+        for path in args.current_root.rglob("*")
+        if path.is_file()
+    }
+    changed_paths = sorted(
+        path
+        for path in set(candidate_paths) | set(current_paths)
+        if candidate_paths.get(path) != current_paths.get(path)
+    )
+
+    report = {
+        "candidate_hash": args.candidate_hash,
+        "deployed_hash": args.deployed_hash,
+        "has_changes": args.candidate_hash != args.deployed_hash,
+        "recreate_services": sorted(set(recreate_services)),
+        "image_services": image_services,
+        "stateful_recreate_services": stateful_services,
+        "missing_runtime_services": sorted(desired_names - runtime_names),
+        "unexpected_runtime_services": sorted(runtime_names - desired_names),
+        "forbidden_actions": forbidden_actions,
+        "changed_paths": changed_paths,
+        "manual_only_paths": [
+            path for path in changed_paths if path.startswith("services/data/")
+        ],
+    }
+    args.output.write_text(
+        json.dumps(report, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    args.output.chmod(0o600)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add merged-commit staging and hash-locked Compose deployment plans
- combine restricted runtime inventories with guarded dry-run actions
- preserve previous artifact/environment and pull only changed image services
- refuse service-set, remove/create, and unclassified `services/data` changes
- require idempotent post-plans, health checks, zero-change post-checks, and full audits

The plan path is disabled until `COMPOSE_AUTO_PLAN_ENABLED=true`. The apply path remains separately disabled unless `COMPOSE_AUTO_APPLY_ENABLED=true`; this PR performs no image pull or container convergence.