### PR TITLE
fix: normalize compose action bind roots

### DIFF
--- a/ansible/roles/compose_deploy/tasks/main.yml
+++ b/ansible/roles/compose_deploy/tasks/main.yml
@@ -95,6 +95,7 @@
       --project-directory {{ compose_staging_root }}/{{ compose_artifact_hash }}
       --env-file {{ compose_staged_env_path }}
       --compose-file {{ compose_staging_root }}/{{ compose_artifact_hash }}/docker-compose.yml
+      --bind-root-override {{ compose_current_dir }}
       --output /run/docker-compose-deploy-actions.json
     executable: python
   become: true

--- a/scripts/compose-action-plan.py
+++ b/scripts/compose-action-plan.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 import re
 import subprocess
+import tempfile
 
 ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 ACTION_PATTERN = re.compile(
@@ -14,40 +15,111 @@ ACTION_PATTERN = re.compile(
 )
 
 
-def main() -> None:
-    parser = ArgumentParser()
-    parser.add_argument("--project-name", required=True)
-    parser.add_argument("--project-directory", required=True, type=Path)
-    parser.add_argument("--env-file", required=True, type=Path)
-    parser.add_argument("--compose-file", required=True, type=Path)
-    parser.add_argument("--output", required=True, type=Path)
-    args = parser.parse_args()
-
+def normalized_compose_file(
+    project_name: str,
+    project_directory: Path,
+    env_file: Path,
+    compose_file: Path,
+    bind_root_override: Path,
+) -> Path:
     result = subprocess.run(
         [
             "/usr/bin/docker",
             "compose",
-            "--ansi",
-            "never",
-            "--dry-run",
             "--project-name",
-            args.project_name,
+            project_name,
             "--project-directory",
-            str(args.project_directory),
+            str(project_directory),
             "--env-file",
-            str(args.env_file),
+            str(env_file),
             "--file",
-            str(args.compose_file),
-            "create",
-            "--no-build",
-            "--pull",
-            "never",
+            str(compose_file),
+            "config",
+            "--format",
+            "json",
         ],
         check=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
     )
+    model = json.loads(result.stdout)
+    project_root = project_directory.resolve()
+    for service in (model.get("services") or {}).values():
+        for mount in service.get("volumes") or []:
+            if mount.get("type") != "bind" or not isinstance(mount.get("source"), str):
+                continue
+            try:
+                relative = Path(mount["source"]).resolve().relative_to(project_root)
+            except ValueError:
+                continue
+            mount["source"] = str(bind_root_override.resolve() / relative)
+
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        prefix="docker-compose-normalized-",
+        suffix=".json",
+        dir="/run",
+        delete=False,
+    ) as handle:
+        json.dump(model, handle, sort_keys=True, separators=(",", ":"))
+        handle.write("\n")
+        return Path(handle.name)
+
+
+def main() -> None:
+    parser = ArgumentParser()
+    parser.add_argument("--project-name", required=True)
+    parser.add_argument("--project-directory", required=True, type=Path)
+    parser.add_argument("--env-file", required=True, type=Path)
+    parser.add_argument("--compose-file", required=True, type=Path)
+    parser.add_argument("--bind-root-override", type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    normalized_file = None
+    dry_run_file = args.compose_file
+    dry_run_project_directory = args.project_directory
+    try:
+        if args.bind_root_override is not None:
+            normalized_file = normalized_compose_file(
+                args.project_name,
+                args.project_directory,
+                args.env_file,
+                args.compose_file,
+                args.bind_root_override,
+            )
+            dry_run_file = normalized_file
+            dry_run_project_directory = args.bind_root_override
+        result = subprocess.run(
+            [
+                "/usr/bin/docker",
+                "compose",
+                "--ansi",
+                "never",
+                "--dry-run",
+                "--project-name",
+                args.project_name,
+                "--project-directory",
+                str(dry_run_project_directory),
+                "--env-file",
+                str(args.env_file),
+                "--file",
+                str(dry_run_file),
+                "create",
+                "--no-build",
+                "--pull",
+                "never",
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    finally:
+        if normalized_file is not None:
+            normalized_file.unlink(missing_ok=True)
     output = ANSI_PATTERN.sub("", result.stdout + result.stderr)
     actions = [
         {"service": service, "action": action}


### PR DESCRIPTION
Normalize candidate bind sources to `/srv/docker-compose/current` inside a root-only temporary resolved model before dry-run comparison. The resolved model is never logged and is removed in a `finally` block.