### PR TITLE
feat: guard renovate compose canary

### DIFF
--- a/.github/workflows/compose-deploy.yml
+++ b/.github/workflows/compose-deploy.yml
@@ -130,7 +130,8 @@ jobs:
           plan_log="$RUNNER_TEMP/compose-deploy-plan.log"
           ansible-playbook -i inventory/production.yml \
             playbooks/deploy-compose.yml --check --diff \
-            -e "compose_artifact_hash=$ARTIFACT_HASH" | tee "$plan_log"
+            -e "compose_artifact_hash=$ARTIFACT_HASH" \
+            -e compose_deploy_canary_only=true | tee "$plan_log"
           recap=$(python ../.github/scripts/parse-ansible-recap.py \
             "$plan_log" docker-host-production)
           changed=$(jq -r '.changed' <<<"$recap")
@@ -210,7 +211,8 @@ jobs:
           replan_log="$RUNNER_TEMP/compose-deploy-replan.log"
           ansible-playbook -i inventory/production.yml \
             playbooks/deploy-compose.yml --check --diff \
-            -e "compose_artifact_hash=$ARTIFACT_HASH" | tee "$replan_log"
+            -e "compose_artifact_hash=$ARTIFACT_HASH" \
+            -e compose_deploy_canary_only=true | tee "$replan_log"
           recap=$(python ../.github/scripts/parse-ansible-recap.py \
             "$replan_log" docker-host-production)
           [[ $(jq -r '.unreachable' <<<"$recap") == 0 ]]
@@ -231,6 +233,7 @@ jobs:
           ansible-playbook -i inventory/production.yml \
             playbooks/deploy-compose.yml \
             -e "compose_artifact_hash=$ARTIFACT_HASH" \
+            -e compose_deploy_canary_only=true \
             -e compose_deploy_confirmed=true | tee "$apply_log"
           recap=$(python ../.github/scripts/parse-ansible-recap.py \
             "$apply_log" docker-host-production)
@@ -250,7 +253,8 @@ jobs:
           post_log="$RUNNER_TEMP/compose-deploy-postcheck.log"
           ansible-playbook -i inventory/production.yml \
             playbooks/deploy-compose.yml --check --diff \
-            -e "compose_artifact_hash=$ARTIFACT_HASH" | tee "$post_log"
+            -e "compose_artifact_hash=$ARTIFACT_HASH" \
+            -e compose_deploy_canary_only=true | tee "$post_log"
           recap=$(python ../.github/scripts/parse-ansible-recap.py \
             "$post_log" docker-host-production)
           [[ $(jq -r '.changed' <<<"$recap") == 0 ]]

--- a/ansible/group_vars/docker_host.yml
+++ b/ansible/group_vars/docker_host.yml
@@ -60,6 +60,8 @@ compose_age_identity_path: /etc/sops/age/keys.txt
 compose_deployed_hash_path: /var/lib/docker-compose/deployed.sha256
 compose_staged_inventory_path: /var/lib/docker-compose/staged-model.json
 compose_runtime_inventory_path: /var/lib/docker-compose/runtime-model.json
+compose_canary_service: flaresolverr
+compose_canary_path: services/servarr.yml
 compose_initial_recreate_services:
   - bookshelf
   - caddy

--- a/ansible/roles/compose_deploy/tasks/main.yml
+++ b/ansible/roles/compose_deploy/tasks/main.yml
@@ -116,6 +116,8 @@
       --current-root {{ compose_current_dir }}
       --candidate-hash {{ compose_artifact_hash }}
       --deployed-hash {{ compose_deploy_recorded_hash.stdout }}
+      --canary-service {{ compose_canary_service }}
+      --canary-path {{ compose_canary_path }}
       --output /run/docker-compose-deploy-plan.json
     executable: python
   become: true
@@ -148,6 +150,13 @@
     - /run/docker-compose-deploy-actions.json
     - /run/docker-compose-deploy-plan.json
 
+- name: Select changes permitted by the requested deployment lane
+  ansible.builtin.set_fact:
+    compose_deploy_effective_changes: >-
+      {{ compose_deploy_plan.has_changes and
+         (not (compose_deploy_canary_only | default(false) | ansible.builtin.bool) or
+          compose_deploy_plan.canary_eligible) }}
+
 - name: Display only the secret-free deployment plan
   ansible.builtin.debug:
     var: compose_deploy_plan
@@ -170,13 +179,13 @@
       recreate_services: "{{ compose_deploy_plan.recreate_services }}"
       image_services: "{{ compose_deploy_plan.image_services }}"
       stateful_recreate_services: "{{ compose_deploy_plan.stateful_recreate_services }}"
-  changed_when: compose_deploy_plan.has_changes
+  changed_when: compose_deploy_effective_changes
   when: ansible_check_mode
 
 - name: Deploy the exact staged Compose artifact
   when:
     - not ansible_check_mode
-    - compose_deploy_plan.has_changes
+    - compose_deploy_effective_changes
   block:
     - name: Pull only changed service images without starting containers
       ansible.builtin.command:

--- a/docs/compose-deployment.md
+++ b/docs/compose-deployment.md
@@ -112,3 +112,15 @@ All temporary enable variables were removed after use. Cutover, failed-lock clea
 The apply job is independently disabled unless `COMPOSE_AUTO_APPLY_ENABLED=true`. A changed merged plan must still match the current `main` tip and reproduce the complete plan hash. Deployment refuses service additions/removals, Docker create/remove actions, and `services/data/**` changes that lack an explicit restart decision. It pulls only services whose reviewed image reference changed, preserves current as `previous` plus a root-only previous environment, rotates the hash-verified artifact before Docker convergence, and runs Compose without builds or orphan removal. No image or volume pruning occurs.
 
 Every apply attempt retains the production lock on failure. Success requires an idempotent post-deployment Compose action plan, all 41 services running, healthy Gluetun and Seerr, a zero-change deployment post-check, and a zero-change complete audit. There is no automatic stateful rollback; the tracked previous artifact and environment are recovery inputs for a separately reviewed rollback.
+
+### Renovate canary lane
+
+The automatic apply lane is initially restricted to `flaresolverr`, a stateless service without a Compose-managed volume. A candidate is canary-eligible only when all checks agree that:
+
+- the candidate changes exactly `services/servarr.yml`;
+- `flaresolverr` is the only image-reference difference;
+- `flaresolverr` is the only proposed recreation;
+- no stateful service, service-set change, create/remove action, secret file, or `services/data/**` path is involved; and
+- the candidate and active artifact identities are exact.
+
+All other Compose changes still produce a protected plan but report zero effective automatic changes, so the apply job cannot start. Renovate Docker updates are ungrouped, have a minimum release age, and default to `automerge: false`; the Flaresolverr package receives the `compose-canary` label and a seven-day release age. `COMPOSE_AUTO_PLAN_ENABLED=true` is active, while `COMPOSE_AUTO_APPLY_ENABLED` remains unset pending explicit canary activation approval.

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,10 @@
     "config:recommended",
     "group:allNonMajor"
   ],
+  "labels": [
+    "dependencies"
+  ],
+  "prConcurrentLimit": 5,
   "packageRules": [
     {
       "matchDepTypes": [
@@ -11,6 +15,31 @@
         "devDependencies"
       ],
       "rangeStrategy": "bump"
+    },
+    {
+      "description": "Keep Docker updates isolated and manually reviewed",
+      "matchDatasources": [
+        "docker"
+      ],
+      "groupName": null,
+      "separateMinorPatch": true,
+      "minimumReleaseAge": "3 days",
+      "automerge": false
+    },
+    {
+      "description": "Mark the sole stateless Compose deployment canary",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/flaresolverr/flaresolverr"
+      ],
+      "labels": [
+        "dependencies",
+        "compose-canary"
+      ],
+      "minimumReleaseAge": "7 days",
+      "automerge": false
     },
     {
       "matchDatasources": [

--- a/scripts/compose-deployment-diff.py
+++ b/scripts/compose-deployment-diff.py
@@ -22,6 +22,8 @@ def main() -> None:
     parser.add_argument("--current-root", required=True, type=Path)
     parser.add_argument("--candidate-hash", required=True)
     parser.add_argument("--deployed-hash", required=True)
+    parser.add_argument("--canary-service", required=True)
+    parser.add_argument("--canary-path", required=True)
     parser.add_argument("--output", required=True, type=Path)
     args = parser.parse_args()
 
@@ -72,6 +74,16 @@ def main() -> None:
         if candidate_paths.get(path) != current_paths.get(path)
     )
 
+    canary_eligible = (
+        args.candidate_hash != args.deployed_hash
+        and image_services == [args.canary_service]
+        and sorted(set(recreate_services)) == [args.canary_service]
+        and not stateful_services
+        and not forbidden_actions
+        and desired_names == runtime_names
+        and changed_paths == [args.canary_path]
+    )
+
     report = {
         "candidate_hash": args.candidate_hash,
         "deployed_hash": args.deployed_hash,
@@ -86,6 +98,9 @@ def main() -> None:
         "manual_only_paths": [
             path for path in changed_paths if path.startswith("services/data/")
         ],
+        "canary_service": args.canary_service,
+        "canary_path": args.canary_path,
+        "canary_eligible": canary_eligible,
     }
     args.output.write_text(
         json.dumps(report, sort_keys=True, separators=(",", ":")) + "\n",


### PR DESCRIPTION
## Summary

- restrict automated Compose changes to the stateless Flaresolverr canary
- require exactly one image difference, one recreation, and one changed Compose file
- make every other merged Compose change plan-only
- ungroup Docker updates, add release-age gates, and keep Renovate automerge disabled

Validated with Renovate 44.9.2 and synthetic canary-policy tests. `COMPOSE_AUTO_APPLY_ENABLED` remains unset, so this PR cannot pull an image or recreate a container.