### PR TITLE
fix: add guarded canary retry

### DIFF
--- a/.github/workflows/compose-deploy.yml
+++ b/.github/workflows/compose-deploy.yml
@@ -29,6 +29,20 @@ on:
       - services/*.yml
       - services/data/**
   workflow_dispatch:
+    inputs:
+      apply_canary:
+        description: Apply one plan-eligible canary after planning
+        required: true
+        default: false
+        type: boolean
+      candidate_sha256:
+        description: Exact reviewed candidate artifact SHA-256
+        required: false
+        type: string
+      confirmation:
+        description: Enter deploy-canary:<candidate_sha256>
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -188,7 +202,8 @@ jobs:
     name: Apply the merged Compose plan
     needs: plan
     if: >-
-      github.event_name == 'push' &&
+      (github.event_name == 'push' ||
+        (github.event_name == 'workflow_dispatch' && inputs.apply_canary)) &&
       needs.plan.outputs.has_changes == 'true' &&
       vars.COMPOSE_AUTO_APPLY_ENABLED == 'true'
     runs-on: ubuntu-24.04
@@ -202,9 +217,12 @@ jobs:
           persist-credentials: false
           ref: ${{ github.sha }}
 
-      - name: Require the planned commit at the tip of main
+      - name: Require the planned commit and optional typed canary confirmation
         env:
           EXPECTED_ARTIFACT_HASH: ${{ needs.plan.outputs.artifact_hash }}
+          APPLY_CANARY: ${{ inputs.apply_canary }}
+          REQUESTED_HASH: ${{ inputs.candidate_sha256 }}
+          CONFIRMATION: ${{ inputs.confirmation }}
         shell: bash
         run: |
           set -euo pipefail
@@ -212,6 +230,11 @@ jobs:
           git fetch --quiet --no-tags origin refs/heads/main
           [[ $(git rev-parse FETCH_HEAD) == "$GITHUB_SHA" ]]
           [[ $(python3 scripts/compose-artifact.py hash) == "$EXPECTED_ARTIFACT_HASH" ]]
+          if [[ $GITHUB_EVENT_NAME == workflow_dispatch ]]; then
+            [[ $APPLY_CANARY == true ]]
+            [[ $REQUESTED_HASH == "$EXPECTED_ARTIFACT_HASH" ]]
+            [[ $CONFIRMATION == "deploy-canary:$EXPECTED_ARTIFACT_HASH" ]]
+          fi
 
       - name: Prepare the restricted apply controller
         uses: ./.github/actions/ansible-controller

--- a/docs/compose-deployment.md
+++ b/docs/compose-deployment.md
@@ -111,7 +111,7 @@ All temporary enable variables were removed after use. Cutover, failed-lock clea
 
 The apply job is independently disabled unless `COMPOSE_AUTO_APPLY_ENABLED=true`. A changed merged plan must still match the current `main` tip and reproduce the complete plan hash. Deployment refuses service additions/removals, Docker create/remove actions, and `services/data/**` changes that lack an explicit restart decision. It pulls only services whose reviewed image reference changed, preserves current as `previous` plus a root-only previous environment, rotates the hash-verified artifact before Docker convergence, and runs Compose without builds or orphan removal. No image or volume pruning occurs.
 
-Every apply attempt retains the production lock on failure. Success requires an idempotent post-deployment Compose action plan, all 41 services running, healthy Gluetun and Seerr, a zero-change deployment post-check, and a zero-change complete audit. There is no automatic stateful rollback; the tracked previous artifact and environment are recovery inputs for a separately reviewed rollback.
+Every apply attempt retains the production lock on failure. Success requires an idempotent post-deployment Compose action plan, all 41 services running, healthy Gluetun and Seerr, a zero-change deployment post-check, and a zero-change complete audit. There is no automatic stateful rollback; the tracked previous artifact and environment are recovery inputs for a separately reviewed rollback. A failed pre-apply canary may be retried manually only with the exact candidate hash, typed `deploy-canary:<candidate-sha256>` confirmation, the same canary-only policy, and the automatic-apply emergency stop enabled.
 
 ### Renovate canary lane
 


### PR DESCRIPTION
Add a manual retry path requiring the exact candidate hash and typed confirmation while preserving the same canary-only policy. This enables recovery from pre-apply validation failures without creating a no-op push. Automatic apply remains disabled.