### PR TITLE
chore: remove retired infrastructure branch access

### DIFF
--- a/infrastructure/policy/fixtures/retired-branch-policy-delete.json
+++ b/infrastructure/policy/fixtures/retired-branch-policy-delete.json
@@ -1,0 +1,1 @@
+{"resource_changes":[{"address":"github_repository_environment_deployment_policy.apply[\"feat/infrastructure-reconciliation\"]","type":"github_repository_environment_deployment_policy","change":{"actions":["delete"],"before":{"branch_pattern":"feat/infrastructure-reconciliation"},"after":null}}]}

--- a/infrastructure/policy/inspect-plan.py
+++ b/infrastructure/policy/inspect-plan.py
@@ -210,6 +210,16 @@ def main() -> int:
                 failures.append(f"{address}: CT mode permits only staged unprotection or deletion of unprotected CT 101")
             continue
 
+        retired_branch_policy_delete = (
+            address
+            == 'github_repository_environment_deployment_policy.apply["feat/infrastructure-reconciliation"]'
+            and actions == ["delete"]
+            and (change.get("before") or {}).get("branch_pattern") == "feat/infrastructure-reconciliation"
+            and change.get("after") is None
+        )
+        if retired_branch_policy_delete:
+            continue
+
         if "delete" in actions:
             failures.append(f"{address}: delete or replacement is forbidden")
             continue

--- a/infrastructure/policy/test-policy.sh
+++ b/infrastructure/policy/test-policy.sh
@@ -12,6 +12,7 @@ python3 "$policy" "$fixtures/network-migration.json" --mode network-migration
 python3 "$policy" "$fixtures/ct-decommission.json" --mode ct-decommission
 python3 "$policy" "$fixtures/ct-unprotect.json" --mode ct-decommission
 python3 "$policy" "$fixtures/protection-enable.json"
+python3 "$policy" "$fixtures/retired-branch-policy-delete.json"
 python3 "$policy" "$fixtures/qualification-create.json" --mode qualification
 python3 "$policy" "$fixtures/qualification-delete.json" --mode qualification
 

--- a/infrastructure/tofu/github/main.tf
+++ b/infrastructure/tofu/github/main.tf
@@ -94,9 +94,12 @@ resource "github_repository_environment_deployment_policy" "apply" {
 }
 
 import {
-  for_each = var.github_enable_management ? var.apply_deployment_policy_import_ids : {}
-  to       = github_repository_environment_deployment_policy.apply[each.key]
-  id       = "${local.repository}:${local.contract.github.environments.apply}:${each.value}"
+  for_each = var.github_enable_management ? {
+    for branch, id in var.apply_deployment_policy_import_ids : branch => id
+    if contains(var.apply_deployment_branches, branch)
+  } : {}
+  to = github_repository_environment_deployment_policy.apply[each.key]
+  id = "${local.repository}:${local.contract.github.environments.apply}:${each.value}"
 }
 
 import {

--- a/infrastructure/tofu/github/variables.tf
+++ b/infrastructure/tofu/github/variables.tf
@@ -48,7 +48,6 @@ variable "github_repository_variable_names_adopt_existing" {
 variable "apply_deployment_branches" {
   type = set(string)
   default = [
-    "feat/infrastructure-reconciliation",
     "main",
   ]
 }


### PR DESCRIPTION
Remove the merged feature branch from the protected apply environment. The plan policy permits only deletion of this exact retired deployment policy; all other deletions remain forbidden.