### PR TITLE
feat: detach legacy Tailscale routes

### DIFF
--- a/.github/scripts/reconcile-apply-source.py
+++ b/.github/scripts/reconcile-apply-source.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Require special infrastructure applies to run from the exact main commit."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Callable, Mapping, Sequence
+
+
+class ApplySourceError(ValueError):
+    """Raised when the current checkout cannot authorize a special apply."""
+
+
+Git = Callable[[Sequence[str]], str]
+
+
+def run_git(arguments: Sequence[str]) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def validate_apply_source(environment: Mapping[str, str], git: Git = run_git) -> None:
+    current_commit = git(("rev-parse", "HEAD"))
+    if re.fullmatch(r"[0-9a-f]{40}", current_commit) is None:
+        raise ApplySourceError("current commit identity is invalid")
+
+    if environment.get("GITHUB_ACTIONS") == "true":
+        if environment.get("GITHUB_REF") != "refs/heads/main":
+            raise ApplySourceError("GitHub lifecycle apply requires exact refs/heads/main")
+        github_sha = environment.get("GITHUB_SHA", "")
+        if re.fullmatch(r"[0-9a-f]{40}", github_sha) is None or current_commit != github_sha:
+            raise ApplySourceError("GitHub lifecycle apply checkout differs from GITHUB_SHA")
+        return
+
+    branch = git(("symbolic-ref", "--quiet", "--short", "HEAD"))
+    if branch != "main":
+        raise ApplySourceError("local lifecycle apply requires the checked-out main branch")
+    origin_main = git(("rev-parse", "origin/main"))
+    if re.fullmatch(r"[0-9a-f]{40}", origin_main) is None or current_commit != origin_main:
+        raise ApplySourceError("local lifecycle apply commit differs from origin/main")
+
+
+def main() -> int:
+    try:
+        validate_apply_source(os.environ)
+        return 0
+    except (ApplySourceError, subprocess.CalledProcessError) as error:
+        print(f"Lifecycle apply source validation failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tailscale-gateway-policy.py
+++ b/.github/scripts/tailscale-gateway-policy.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Validate the guarded Tailscale gateway-policy lifecycle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Any, TextIO
+
+STAGES = {"active", "detached", "retired"}
+OPERATIONS = {"none", "detach", "retire"}
+DEVICE_ABSENCE_APPROVAL_ENVIRONMENT = "TAILSCALE_GATEWAY_DEVICE_ABSENCE_APPROVED"
+TRANSITION_OPERATIONS = {
+    ("active", "active"): "none",
+    ("active", "detached"): "detach",
+    ("detached", "active"): "none",
+    ("detached", "detached"): "none",
+    ("detached", "retired"): "retire",
+    ("retired", "retired"): "none",
+}
+
+
+class GatewayPolicyError(ValueError):
+    """Raised when a gateway-policy lifecycle invariant is not met."""
+
+
+def contract_value(path: Path, target: tuple[str, ...]) -> str:
+    ancestors: list[tuple[int, str]] = []
+    for line in path.read_text().splitlines():
+        match = re.match(r"^( *)([A-Za-z_][A-Za-z0-9_]*):(?:[ ]+(.*))?$", line)
+        if not match:
+            continue
+        indent = len(match.group(1))
+        key = match.group(2)
+        value = match.group(3)
+        while ancestors and indent <= ancestors[-1][0]:
+            ancestors.pop()
+        current = tuple(entry[1] for entry in ancestors) + (key,)
+        if current == target:
+            return (value or "").split(" #", 1)[0].strip().strip("\"'")
+        if value is None:
+            ancestors.append((indent, key))
+    raise GatewayPolicyError(f"contract value {'.'.join(target)} is missing")
+
+
+def gateway_stage(path: Path, legacy_active: bool = False) -> str:
+    try:
+        stage = contract_value(path, ("tailscale", "gateway_policy_stage"))
+    except GatewayPolicyError:
+        if legacy_active:
+            return "active"
+        raise
+    if stage not in STAGES:
+        raise GatewayPolicyError("contract gateway_policy_stage is invalid")
+    return stage
+
+
+def ct_stage(path: Path) -> str:
+    stage = contract_value(path, ("proxmox", "legacy_container", "retirement_stage"))
+    if stage not in {"protected", "unprotected", "retired"}:
+        raise GatewayPolicyError("contract CT retirement_stage is invalid")
+    return stage
+
+
+def operation_matches_stage(operation: str, stage: str, container_stage: str) -> bool:
+    if operation not in OPERATIONS or stage not in STAGES:
+        return False
+    if stage == "active" and container_stage == "retired":
+        return False
+    if stage == "retired" and container_stage != "retired":
+        return False
+    if operation == "none":
+        return True
+    if operation == "detach":
+        return stage == "detached"
+    return stage == "retired" and container_stage == "retired"
+
+
+def device_absence_approved(operation: str) -> bool:
+    return operation != "retire" or os.environ.get(DEVICE_ABSENCE_APPROVAL_ENVIRONMENT) == "true"
+
+
+def transition_operation(base: Path, head: Path) -> str:
+    base_gateway = gateway_stage(base, legacy_active=True)
+    head_gateway = gateway_stage(head)
+    base_ct = ct_stage(base)
+    head_ct = ct_stage(head)
+    try:
+        operation = TRANSITION_OPERATIONS[(base_gateway, head_gateway)]
+    except KeyError as error:
+        raise GatewayPolicyError("gateway_policy_stage transition is not permitted") from error
+    if base_gateway != head_gateway and base_ct != head_ct:
+        raise GatewayPolicyError("gateway-policy and CT retirement transitions cannot be combined")
+    if (base_gateway, head_gateway) == ("detached", "active") and (
+        base_ct == "retired" or head_ct == "retired"
+    ):
+        raise GatewayPolicyError("gateway-policy rollback is forbidden after CT retirement")
+    if operation == "retire" and not (base_ct == head_ct == "retired"):
+        raise GatewayPolicyError("gateway-policy retirement requires an already retired CT")
+    return operation
+
+
+def reject_json_constant(value: str) -> None:
+    raise GatewayPolicyError(f"policy JSON contains invalid constant {value}")
+
+
+def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise GatewayPolicyError(f"policy JSON contains duplicate key {key}")
+        result[key] = value
+    return result
+
+
+def parse_policy_json(value: str) -> dict[str, Any]:
+    try:
+        policy = json.loads(
+            value,
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=reject_json_constant,
+        )
+    except json.JSONDecodeError as error:
+        raise GatewayPolicyError("policy JSON is not canonicalizable") from error
+    if not isinstance(policy, dict):
+        raise GatewayPolicyError("policy JSON must contain an object")
+    return policy
+
+
+def canonical_policy(policy: dict[str, Any]) -> str:
+    try:
+        return json.dumps(
+            policy,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ) + "\n"
+    except (TypeError, ValueError) as error:
+        raise GatewayPolicyError("policy JSON is not canonicalizable") from error
+
+
+def policy_from_plan(plan: Any, side: str) -> dict[str, Any]:
+    if side not in {"before", "after"} or not isinstance(plan, dict):
+        raise GatewayPolicyError("saved plan policy input is invalid")
+    changes = plan.get("resource_changes")
+    if not isinstance(changes, list):
+        raise GatewayPolicyError("saved plan resource changes are missing")
+    matches = [
+        change
+        for change in changes
+        if isinstance(change, dict)
+        and change.get("address") == "terraform_data.tailscale_policy[0]"
+    ]
+    if len(matches) != 1:
+        raise GatewayPolicyError("saved plan must contain exactly one Tailscale policy resource")
+    change = matches[0].get("change")
+    side_value = change.get(side) if isinstance(change, dict) else None
+    input_value = side_value.get("input") if isinstance(side_value, dict) else None
+    policy_json = input_value.get("policy_json") if isinstance(input_value, dict) else None
+    if not isinstance(policy_json, str):
+        raise GatewayPolicyError(f"saved plan Tailscale {side} policy JSON is missing")
+    return parse_policy_json(policy_json)
+
+
+def canonical_policy_sha256(policy: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_policy(policy).encode()).hexdigest()
+
+
+def validate_policy_sha(label: str, value: str) -> None:
+    if re.fullmatch(r"[0-9a-f]{64}", value) is None:
+        raise GatewayPolicyError(f"{label} policy SHA is invalid")
+
+
+def validate_etag(label: str, value: str) -> None:
+    if re.fullmatch(r'(?:W/)?"[^"\x00-\x1f\x7f]+"', value) is None:
+        raise GatewayPolicyError(f"{label} ETag is invalid")
+
+
+def validate_before_identity(planned_before_sha: str, live_before_sha: str) -> None:
+    validate_policy_sha("planned before", planned_before_sha)
+    validate_policy_sha("live before", live_before_sha)
+    if planned_before_sha != live_before_sha:
+        raise GatewayPolicyError("saved plan before policy differs from the live policy captured at plan time")
+
+
+def apply_disposition(
+    current_sha: str,
+    current_etag: str,
+    planned_before_sha: str,
+    planned_after_sha: str,
+    planned_etag: str,
+) -> str:
+    for label, value in (
+        ("current", current_sha),
+        ("planned before", planned_before_sha),
+        ("planned after", planned_after_sha),
+    ):
+        validate_policy_sha(label, value)
+    validate_etag("current", current_etag)
+    validate_etag("planned", planned_etag)
+    if planned_before_sha == planned_after_sha:
+        raise GatewayPolicyError("saved lifecycle plan does not change the policy")
+    if current_sha == planned_after_sha:
+        return "recovered"
+    if current_sha != planned_before_sha or current_etag != planned_etag:
+        raise GatewayPolicyError("live Tailscale policy differs from the saved-plan before identity")
+    return "post"
+
+
+def read_json_input(path: str) -> Any:
+    input_file: TextIO
+    if path == "-":
+        input_file = sys.stdin
+    else:
+        input_file = Path(path).open(encoding="utf-8")
+    try:
+        return json.load(
+            input_file,
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=reject_json_constant,
+        )
+    finally:
+        if path != "-":
+            input_file.close()
+
+
+def verify_manifest_fields(manifest: Any, operation: str, stage: str) -> None:
+    if not isinstance(manifest, dict) or manifest.get("version") != 2:
+        raise GatewayPolicyError("saved-plan manifest version is invalid")
+    if manifest.get("tailscale_gateway_operation") != operation:
+        raise GatewayPolicyError("saved-plan manifest gateway operation mismatch")
+    if manifest.get("tailscale_gateway_policy_stage") != stage:
+        raise GatewayPolicyError("saved-plan manifest gateway stage mismatch")
+    plans = manifest.get("plans", [])
+    tailscale_plans = [plan for plan in plans if isinstance(plan, dict) and plan.get("root") == "tailscale"] if isinstance(plans, list) else []
+    if len(tailscale_plans) > 1:
+        raise GatewayPolicyError("saved-plan manifest has duplicate Tailscale roots")
+    if tailscale_plans:
+        plan = tailscale_plans[0]
+        before = plan.get("tailscale_policy_before_sha256")
+        after = plan.get("tailscale_policy_after_sha256")
+        etag = plan.get("tailscale_policy_etag")
+        if not isinstance(before, str) or re.fullmatch(r"[0-9a-f]{64}", before) is None:
+            raise GatewayPolicyError("saved-plan manifest Tailscale before SHA is invalid")
+        if not isinstance(after, str) or re.fullmatch(r"[0-9a-f]{64}", after) is None:
+            raise GatewayPolicyError("saved-plan manifest Tailscale after SHA is invalid")
+        if not isinstance(etag, str) or re.fullmatch(r'(?:W/)?"[^"\x00-\x1f\x7f]+"', etag) is None:
+            raise GatewayPolicyError("saved-plan manifest Tailscale ETag is invalid")
+        if operation != "none" and before == after:
+            raise GatewayPolicyError("saved-plan manifest lifecycle policy is unchanged")
+    elif operation != "none":
+        raise GatewayPolicyError("saved-plan manifest is missing the Tailscale root")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate = subparsers.add_parser("validate-operation")
+    validate.add_argument("--contract", type=Path, required=True)
+    validate.add_argument("--operation", choices=sorted(OPERATIONS), required=True)
+
+    transition = subparsers.add_parser("transition")
+    transition.add_argument("--base-contract", type=Path, required=True)
+    transition.add_argument("--head-contract", type=Path, required=True)
+    transition.add_argument("--github-output", type=Path)
+
+    manifest = subparsers.add_parser("verify-manifest")
+    manifest.add_argument("--manifest", type=Path, required=True)
+    manifest.add_argument("--contract", type=Path, required=True)
+    manifest.add_argument("--operation", choices=sorted(OPERATIONS), required=True)
+
+    canonicalize = subparsers.add_parser("canonicalize-policy")
+    canonicalize.add_argument("--policy", required=True)
+
+    extract = subparsers.add_parser("extract-plan-policy")
+    extract.add_argument("--plan-json", required=True)
+    extract.add_argument("--side", choices=("before", "after"), required=True)
+
+    before_identity = subparsers.add_parser("validate-before-identity")
+    before_identity.add_argument("--planned-before-sha", required=True)
+    before_identity.add_argument("--live-before-sha", required=True)
+
+    disposition = subparsers.add_parser("apply-disposition")
+    disposition.add_argument("--current-sha", required=True)
+    disposition.add_argument("--current-etag", required=True)
+    disposition.add_argument("--planned-before-sha", required=True)
+    disposition.add_argument("--planned-after-sha", required=True)
+    disposition.add_argument("--planned-etag", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.command == "canonicalize-policy":
+            policy = read_json_input(args.policy)
+            if not isinstance(policy, dict):
+                raise GatewayPolicyError("policy JSON must contain an object")
+            sys.stdout.write(canonical_policy(policy))
+            return 0
+        if args.command == "extract-plan-policy":
+            sys.stdout.write(canonical_policy(policy_from_plan(read_json_input(args.plan_json), args.side)))
+            return 0
+        if args.command == "validate-before-identity":
+            validate_before_identity(args.planned_before_sha, args.live_before_sha)
+            return 0
+        if args.command == "apply-disposition":
+            print(apply_disposition(
+                args.current_sha,
+                args.current_etag,
+                args.planned_before_sha,
+                args.planned_after_sha,
+                args.planned_etag,
+            ))
+            return 0
+        if args.command == "validate-operation":
+            stage = gateway_stage(args.contract)
+            if not operation_matches_stage(args.operation, stage, ct_stage(args.contract)):
+                raise GatewayPolicyError("gateway operation does not match the contract stages")
+            if not device_absence_approved(args.operation):
+                raise GatewayPolicyError("retirement requires exact protected device-absence approval")
+            return 0
+        if args.command == "transition":
+            operation = transition_operation(args.base_contract, args.head_contract)
+            if args.github_output:
+                with args.github_output.open("a") as output:
+                    output.write(f"operation={operation}\n")
+            else:
+                print(operation)
+            return 0
+        stage = gateway_stage(args.contract)
+        if not operation_matches_stage(args.operation, stage, ct_stage(args.contract)):
+            raise GatewayPolicyError("gateway operation does not match the contract stages")
+        if not device_absence_approved(args.operation):
+            raise GatewayPolicyError("retirement requires exact protected device-absence approval")
+        verify_manifest_fields(json.loads(args.manifest.read_text()), args.operation, stage)
+        return 0
+    except (OSError, json.JSONDecodeError, UnicodeError, GatewayPolicyError) as error:
+        print(f"Tailscale gateway-policy validation failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test-reconcile-apply-source.py
+++ b/.github/scripts/test-reconcile-apply-source.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Focused tests for main-only special infrastructure applies."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+HELPER = Path(__file__).with_name("reconcile-apply-source.py")
+
+
+def load_helper():
+    spec = importlib.util.spec_from_file_location("reconcile_apply_source", HELPER)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {HELPER}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+source = load_helper()
+COMMIT = "a" * 40
+OTHER_COMMIT = "b" * 40
+
+
+class FakeGit:
+    def __init__(self, *, branch: str = "main", origin_main: str = COMMIT) -> None:
+        self.branch = branch
+        self.origin_main = origin_main
+
+    def __call__(self, arguments: tuple[str, ...]) -> str:
+        values = {
+            ("rev-parse", "HEAD"): COMMIT,
+            ("symbolic-ref", "--quiet", "--short", "HEAD"): self.branch,
+            ("rev-parse", "origin/main"): self.origin_main,
+        }
+        return values[arguments]
+
+
+class ApplySourceTests(unittest.TestCase):
+    def test_github_requires_exact_main_ref_and_candidate_commit(self) -> None:
+        valid = {"GITHUB_ACTIONS": "true", "GITHUB_REF": "refs/heads/main", "GITHUB_SHA": COMMIT}
+        source.validate_apply_source(valid, FakeGit())
+        for environment in (
+            {**valid, "GITHUB_REF": "refs/pull/7/merge"},
+            {**valid, "GITHUB_REF": "refs/heads/feature"},
+            {**valid, "GITHUB_SHA": OTHER_COMMIT},
+            {**valid, "GITHUB_SHA": ""},
+        ):
+            with self.assertRaises(source.ApplySourceError):
+                source.validate_apply_source(environment, FakeGit())
+
+    def test_local_requires_attached_main_at_origin_main(self) -> None:
+        source.validate_apply_source({}, FakeGit())
+        for git in (
+            FakeGit(branch="feature"),
+            FakeGit(branch="HEAD"),
+            FakeGit(origin_main=OTHER_COMMIT),
+        ):
+            with self.assertRaises(source.ApplySourceError):
+                source.validate_apply_source({}, git)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test-tailscale-gateway-policy.py
+++ b/.github/scripts/test-tailscale-gateway-policy.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Focused lifecycle, real-root rendering, and plan-policy tests."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import importlib.util
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+REPOSITORY = Path(__file__).resolve().parents[2]
+HELPER = Path(__file__).with_name("tailscale-gateway-policy.py")
+INSPECTOR = REPOSITORY / "infrastructure/policy/inspect-plan.py"
+
+
+def load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gateway = load(HELPER, "tailscale_gateway_policy")
+inspector = load(INSPECTOR, "tailscale_policy_inspector")
+
+
+def contract(path: Path, gateway_stage: str, ct_stage: str) -> None:
+    path.write_text(
+        "proxmox:\n  legacy_container:\n    retirement_stage: " + ct_stage
+        + "\ntailscale:\n  gateway_policy_stage: " + gateway_stage + "\n"
+    )
+
+
+def plan(before: dict, after: dict, extra_changes: list[dict] | None = None) -> dict:
+    changes = [{
+        "address": "terraform_data.tailscale_policy[0]",
+        "type": "terraform_data",
+        "mode": "managed",
+        "change": {
+            "actions": ["update"],
+            "before": {"input": {"policy_json": json.dumps(before, separators=(",", ":"))}},
+            "after": {"input": {"policy_json": json.dumps(after, separators=(",", ":"))}},
+        },
+    }]
+    changes.extend(extra_changes or [])
+    return {"resource_changes": changes}
+
+
+class GatewayLifecycleTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.policies = cls.render_real_root_policies()
+
+    @staticmethod
+    def render_real_root_policies() -> dict[str, dict]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "infrastructure/tofu/tailscale"
+            root.mkdir(parents=True)
+            shutil.copy(REPOSITORY / "infrastructure/tofu/tailscale/main.tf", root / "main.tf")
+            versions = (REPOSITORY / "infrastructure/tofu/tailscale/versions.tf").read_text()
+            versions = re.sub(r'\n  backend "s3" \{.*?\n  \}\n', "\n", versions, flags=re.DOTALL)
+            (root / "versions.tf").write_text(versions)
+            contract_dir = Path(directory) / "infrastructure/contract"
+            contract_dir.mkdir(parents=True)
+            shutil.copy(REPOSITORY / "infrastructure/contract/home-lab.yml", contract_dir / "home-lab.yml")
+            subprocess.run(["tofu", f"-chdir={root}", "init", "-backend=false", "-input=false"], check=True, capture_output=True, text=True)
+            rendered: dict[str, dict] = {}
+            for stage in ("active", "detached", "retired"):
+                expression = f"jsonencode(local.{stage}_policy)\n"
+                result = subprocess.run(["tofu", f"-chdir={root}", "console"], input=expression, check=True, capture_output=True, text=True)
+                rendered[stage] = json.loads(json.loads(result.stdout.strip()))
+            return rendered
+
+    def test_real_root_exact_stages_and_unrelated_policy(self) -> None:
+        active = self.policies["active"]
+        detached = self.policies["detached"]
+        retired = self.policies["retired"]
+        self.assertEqual(detached, inspector.detached_gateway_policy(active))
+        self.assertEqual(retired, inspector.retired_gateway_policy(detached))
+        for field in ("tests", "sshTests"):
+            self.assertEqual(active[field], detached[field])
+            self.assertEqual(detached[field], retired[field])
+        self.assertNotIn("autoApprovers", detached)
+        self.assertFalse(inspector.contains_exact(detached, "tag:ci"))
+        self.assertFalse(inspector.contains_exact(retired, "tag:infra-router"))
+
+    def test_transition_and_cross_lifecycle_rules(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory) / "base.yml"
+            head = Path(directory) / "head.yml"
+            permitted = {
+                ("active", "active", "protected", "protected"): "none",
+                ("active", "detached", "protected", "protected"): "detach",
+                ("detached", "active", "unprotected", "unprotected"): "none",
+                ("detached", "retired", "retired", "retired"): "retire",
+                ("retired", "retired", "retired", "retired"): "none",
+            }
+            for stages, operation in permitted.items():
+                contract(base, stages[0], stages[2])
+                contract(head, stages[1], stages[3])
+                self.assertEqual(gateway.transition_operation(base, head), operation)
+            rejected = (
+                ("active", "retired", "retired", "retired"),
+                ("retired", "detached", "retired", "retired"),
+                ("detached", "active", "retired", "retired"),
+                ("active", "detached", "protected", "unprotected"),
+                ("detached", "active", "protected", "unprotected"),
+                ("detached", "retired", "unprotected", "unprotected"),
+            )
+            for stages in rejected:
+                contract(base, stages[0], stages[2])
+                contract(head, stages[1], stages[3])
+                with self.assertRaises(gateway.GatewayPolicyError):
+                    gateway.transition_operation(base, head)
+
+    def run_policy(self, before: dict, after: dict, mode: str, extra_changes: list[dict] | None = None) -> subprocess.CompletedProcess[str]:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as fixture:
+            json.dump(plan(before, after, extra_changes), fixture)
+            fixture.flush()
+            return subprocess.run(["python3", str(INSPECTOR), fixture.name, "--mode", mode], check=False, capture_output=True, text=True)
+
+    def test_exact_detach_and_retire_plans(self) -> None:
+        self.assertEqual(self.run_policy(self.policies["active"], self.policies["detached"], "ct-gateway-detach").returncode, 0)
+        self.assertEqual(self.run_policy(self.policies["detached"], self.policies["retired"], "ct-gateway-retire").returncode, 0)
+
+    def test_normal_rejects_required_lifecycle_mutation_but_allows_pre_retirement_rollback_shape(self) -> None:
+        self.assertNotEqual(self.run_policy(self.policies["active"], self.policies["detached"], "normal").returncode, 0)
+        self.assertEqual(self.run_policy(self.policies["detached"], self.policies["active"], "normal").returncode, 0)
+
+    def test_noop_repeat_extra_identity_and_wrong_mode_are_rejected(self) -> None:
+        active, detached, retired = (self.policies[name] for name in ("active", "detached", "retired"))
+        for before, after, mode in (
+            (detached, detached, "ct-gateway-detach"),
+            (retired, retired, "ct-gateway-retire"),
+            (active, detached, "ct-gateway-retire"),
+        ):
+            self.assertNotEqual(self.run_policy(before, after, mode).returncode, 0)
+
+        identity_addresses = (
+            "tailscale_federated_identity.ci_apply[0]",
+            "tailscale_federated_identity.ci_plan[0]",
+            "tailscale_federated_identity.provider_apply[0]",
+            "tailscale_federated_identity.provider_plan[0]",
+        )
+        for address, field in zip(identity_addresses, ("tags", "subject", "scopes", "issuer"), strict=True):
+            identity_change = {
+                "address": address,
+                "type": "tailscale_federated_identity",
+                "mode": "managed",
+                "change": {"actions": ["update"], "before": {field: ["before"]}, "after": {field: ["after"]}},
+            }
+            self.assertNotEqual(self.run_policy(active, detached, "ct-gateway-detach", [identity_change]).returncode, 0)
+        root_change = {
+            "address": "aws_s3_bucket.example",
+            "type": "aws_s3_bucket",
+            "mode": "managed",
+            "change": {"actions": ["update"], "before": {"name": "before"}, "after": {"name": "after"}},
+        }
+        self.assertNotEqual(self.run_policy(active, detached, "ct-gateway-detach", [root_change]).returncode, 0)
+
+    def test_unrelated_and_wrong_occurrence_mutations_are_rejected(self) -> None:
+        active = self.policies["active"]
+        detached = self.policies["detached"]
+        mutations = []
+        for field in ("tests", "sshTests"):
+            changed = deepcopy(detached)
+            changed[field] = []
+            mutations.append(changed)
+        for field, value in (("autoApprovers", {}), ("tagOwners", {})):
+            changed = deepcopy(detached)
+            changed[field] = value
+            mutations.append(changed)
+        changed = deepcopy(detached)
+        changed["grants"][0]["src"] = ["autogroup:owner"]
+        mutations.append(changed)
+        changed = deepcopy(detached)
+        changed["ssh"][0]["src"] = ["autogroup:admin"]
+        mutations.append(changed)
+        malformed_before = deepcopy(active)
+        malformed_before["grants"][3]["src"].append("tag:ci")
+        self.assertNotEqual(self.run_policy(malformed_before, detached, "ct-gateway-detach").returncode, 0)
+        for changed in mutations:
+            self.assertNotEqual(self.run_policy(active, changed, "ct-gateway-detach").returncode, 0)
+
+    def test_legacy_base_defaults_active_but_head_requires_stage(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory) / "base.yml"
+            head = Path(directory) / "head.yml"
+            base.write_text("proxmox:\n  legacy_container:\n    retirement_stage: protected\ntailscale:\n  tags: {}\n")
+            contract(head, "detached", "protected")
+            self.assertEqual(gateway.transition_operation(base, head), "detach")
+            with self.assertRaises(gateway.GatewayPolicyError):
+                gateway.gateway_stage(base)
+
+    def test_retire_requires_exact_temporary_device_absence_approval(self) -> None:
+        for environment, expected in (({}, False), ({gateway.DEVICE_ABSENCE_APPROVAL_ENVIRONMENT: "false"}, False), ({gateway.DEVICE_ABSENCE_APPROVAL_ENVIRONMENT: "true"}, True)):
+            with mock.patch.dict("os.environ", environment, clear=True):
+                self.assertEqual(gateway.device_absence_approved("retire"), expected)
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertTrue(gateway.device_absence_approved("detach"))
+
+    def test_retire_cli_fails_closed_without_device_absence_approval(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "contract.yml"
+            contract(target, "retired", "retired")
+            command = ["python3", str(HELPER), "validate-operation", "--contract", str(target), "--operation", "retire"]
+            denied = subprocess.run(command, check=False, capture_output=True, text=True, env={})
+            self.assertNotEqual(denied.returncode, 0)
+            approved = subprocess.run(command, check=False, capture_output=True, text=True, env={gateway.DEVICE_ABSENCE_APPROVAL_ENVIRONMENT: "true"})
+            self.assertEqual(approved.returncode, 0)
+
+    def test_saved_plan_before_and_after_are_canonicalized_identically(self) -> None:
+        active = self.policies["active"]
+        detached = self.policies["detached"]
+        saved_plan = plan(active, detached)
+        planned_before = gateway.policy_from_plan(saved_plan, "before")
+        planned_after = gateway.policy_from_plan(saved_plan, "after")
+        self.assertEqual(
+            gateway.canonical_policy_sha256(planned_before),
+            gateway.canonical_policy_sha256(active),
+        )
+        self.assertEqual(
+            gateway.canonical_policy_sha256(planned_after),
+            gateway.canonical_policy_sha256(detached),
+        )
+
+    def test_missing_or_noncanonical_saved_plan_before_is_rejected(self) -> None:
+        active = self.policies["active"]
+        detached = self.policies["detached"]
+        missing_before = plan(active, detached)
+        del missing_before["resource_changes"][0]["change"]["before"]["input"]["policy_json"]
+        duplicate_key_before = plan(active, detached)
+        duplicate_key_before["resource_changes"][0]["change"]["before"]["input"]["policy_json"] = '{"grants":[],"grants":[]}'
+        duplicate_resource = plan(active, detached)
+        duplicate_resource["resource_changes"].append(deepcopy(duplicate_resource["resource_changes"][0]))
+        for saved_plan in (missing_before, duplicate_key_before, duplicate_resource):
+            with self.assertRaises(gateway.GatewayPolicyError):
+                gateway.policy_from_plan(saved_plan, "before")
+
+    def test_unrelated_live_drift_cannot_authorize_saved_plan_before(self) -> None:
+        planned_before = self.policies["active"]
+        unrelated_live_drift = deepcopy(planned_before)
+        unrelated_live_drift["tests"].append({
+            "src": "autogroup:owner",
+            "proto": "tcp",
+            "accept": ["autogroup:self:443"],
+        })
+        planned_sha = gateway.canonical_policy_sha256(planned_before)
+        live_sha = gateway.canonical_policy_sha256(unrelated_live_drift)
+        self.assertNotEqual(planned_sha, live_sha)
+        with self.assertRaises(gateway.GatewayPolicyError):
+            gateway.validate_before_identity(planned_sha, live_sha)
+        gateway.validate_before_identity(planned_sha, planned_sha)
+
+        planned_after_sha = gateway.canonical_policy_sha256(self.policies["detached"])
+        with self.assertRaises(gateway.GatewayPolicyError):
+            gateway.apply_disposition(
+                live_sha,
+                '"plan-etag"',
+                planned_sha,
+                planned_after_sha,
+                '"plan-etag"',
+            )
+        self.assertEqual(
+            gateway.apply_disposition(
+                planned_sha,
+                '"plan-etag"',
+                planned_sha,
+                planned_after_sha,
+                '"plan-etag"',
+            ),
+            "post",
+        )
+        self.assertEqual(
+            gateway.apply_disposition(
+                planned_after_sha,
+                '"new-etag"',
+                planned_sha,
+                planned_after_sha,
+                '"plan-etag"',
+            ),
+            "recovered",
+        )
+
+    def test_operation_and_manifest_binding(self) -> None:
+        self.assertTrue(gateway.operation_matches_stage("detach", "detached", "protected"))
+        self.assertTrue(gateway.operation_matches_stage("retire", "retired", "retired"))
+        self.assertFalse(gateway.operation_matches_stage("retire", "retired", "unprotected"))
+        self.assertFalse(gateway.operation_matches_stage("none", "active", "retired"))
+        self.assertFalse(gateway.operation_matches_stage("none", "retired", "unprotected"))
+        policy_record = {
+            "root": "tailscale",
+            "tailscale_policy_before_sha256": "a" * 64,
+            "tailscale_policy_after_sha256": "b" * 64,
+            "tailscale_policy_etag": 'W/"reviewed-etag"',
+        }
+        valid = {
+            "version": 2,
+            "tailscale_gateway_operation": "detach",
+            "tailscale_gateway_policy_stage": "detached",
+            "plans": [policy_record],
+        }
+        gateway.verify_manifest_fields(valid, "detach", "detached")
+        invalid = (
+            {**valid, "tailscale_gateway_operation": "none"},
+            {**valid, "tailscale_gateway_policy_stage": "active"},
+            {**valid, "plans": [{**policy_record, "tailscale_policy_before_sha256": ""}]},
+            {**valid, "plans": [{**policy_record, "tailscale_policy_after_sha256": ""}]},
+            {**valid, "plans": [{**policy_record, "tailscale_policy_etag": "unquoted"}]},
+            {**valid, "plans": [{**policy_record, "tailscale_policy_after_sha256": "a" * 64}]},
+        )
+        for changed in invalid:
+            with self.assertRaises(gateway.GatewayPolicyError):
+                gateway.verify_manifest_fields(changed, "detach", "detached")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/compose-artifact.yml
+++ b/.github/workflows/compose-artifact.yml
@@ -62,6 +62,9 @@ jobs:
             python3 .github/scripts/ct-retirement.py transition \
               --base-contract .local/ct-retirement-base/infrastructure/contract/home-lab.yml \
               --head-contract infrastructure/contract/home-lab.yml >/dev/null
+            python3 .github/scripts/tailscale-gateway-policy.py transition \
+              --base-contract .local/ct-retirement-base/infrastructure/contract/home-lab.yml \
+              --head-contract infrastructure/contract/home-lab.yml >/dev/null
           fi
 
       - name: Prove deterministic artifact selection and copy

--- a/.github/workflows/infrastructure-reconcile.yml
+++ b/.github/workflows/infrastructure-reconcile.yml
@@ -43,6 +43,15 @@ on:
           - none
           - unprotect
           - delete
+      tailscale_gateway:
+        description: Select the guarded Tailscale gateway-policy lifecycle
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - detach
+          - retire
       network_migration:
         description: Permit only the reviewed Proxmox hardware-mapping migration
         required: false
@@ -218,6 +227,15 @@ jobs:
             --head-contract infrastructure/contract/home-lab.yml \
             --github-output "$GITHUB_OUTPUT"
 
+      - name: Select the reviewed Tailscale gateway-policy preview
+        id: tailscale-gateway
+        run: |
+          set -euo pipefail
+          python .github/scripts/tailscale-gateway-policy.py transition \
+            --base-contract .local/ct-retirement-base/infrastructure/contract/home-lab.yml \
+            --head-contract infrastructure/contract/home-lab.yml \
+            --github-output "$GITHUB_OUTPUT"
+
       - name: Create policy-inspected saved plans
         env:
           PROXMOX_CT_DECOMMISSION_CONFIRMATION: ${{ secrets.PROXMOX_CT_DECOMMISSION_CONFIRMATION }}
@@ -246,6 +264,7 @@ jobs:
           OMADA_CA_PEM: ${{ secrets.OMADA_CA_PEM }}
           SSL_CERT_FILE: ${{ github.workspace }}/.local/provider-ca/bundle.pem
           TF_VAR_tailscale_enable_management: ${{ vars.TAILSCALE_MANAGEMENT_ENABLED }}
+          TAILSCALE_GATEWAY_DEVICE_ABSENCE_APPROVED: ${{ vars.TAILSCALE_GATEWAY_DEVICE_ABSENCE_APPROVED }}
           TF_VAR_github_owner_id: ${{ vars.TAILSCALE_SUBJECT_OWNER_ID }}
           TF_VAR_github_repository_id: ${{ vars.TAILSCALE_SUBJECT_REPOSITORY_ID }}
           TF_VAR_github_enable_management: ${{ vars.INFRASTRUCTURE_GITHUB_MANAGEMENT_ENABLED }}
@@ -265,7 +284,8 @@ jobs:
           ./scripts/prepare-provider-ca-bundle
           ./scripts/prepare-omada-plan-input
           ./scripts/reconcile-infrastructure plan --phase steady \
-            --ct-operation '${{ steps.ct-retirement.outputs.operation }}'
+            --ct-operation '${{ steps.ct-retirement.outputs.operation }}' \
+            --tailscale-gateway-operation '${{ steps.tailscale-gateway.outputs.operation }}'
 
   dispatch-plan:
     name: Plan dispatched infrastructure
@@ -355,6 +375,7 @@ jobs:
           TF_VAR_qualification_ip: ${{ secrets.OMADA_QUALIFICATION_IP }}
           SSL_CERT_FILE: ${{ github.workspace }}/.local/provider-ca/bundle.pem
           TF_VAR_tailscale_enable_management: ${{ vars.TAILSCALE_MANAGEMENT_ENABLED }}
+          TAILSCALE_GATEWAY_DEVICE_ABSENCE_APPROVED: ${{ vars.TAILSCALE_GATEWAY_DEVICE_ABSENCE_APPROVED }}
           TF_VAR_github_owner_id: ${{ vars.TAILSCALE_SUBJECT_OWNER_ID }}
           TF_VAR_github_repository_id: ${{ vars.TAILSCALE_SUBJECT_REPOSITORY_ID }}
           TF_VAR_github_enable_management: ${{ vars.INFRASTRUCTURE_GITHUB_MANAGEMENT_ENABLED }}
@@ -378,7 +399,8 @@ jobs:
             migration_args+=(--network-migration)
           fi
           ./scripts/reconcile-infrastructure plan --phase '${{ inputs.phase }}' \
-            --ct-operation '${{ inputs.ct_retirement }}' "${migration_args[@]}"
+            --ct-operation '${{ inputs.ct_retirement }}' \
+            --tailscale-gateway-operation '${{ inputs.tailscale_gateway }}' "${migration_args[@]}"
 
       - name: Encrypt the exact saved-plan bundle
         env:
@@ -532,6 +554,7 @@ jobs:
           TF_VAR_qualification_ip: ${{ secrets.OMADA_QUALIFICATION_IP }}
           SSL_CERT_FILE: ${{ github.workspace }}/.local/provider-ca/bundle.pem
           TF_VAR_tailscale_enable_management: ${{ vars.TAILSCALE_MANAGEMENT_ENABLED }}
+          TAILSCALE_GATEWAY_DEVICE_ABSENCE_APPROVED: ${{ vars.TAILSCALE_GATEWAY_DEVICE_ABSENCE_APPROVED }}
           TF_VAR_github_owner_id: ${{ vars.TAILSCALE_SUBJECT_OWNER_ID }}
           TF_VAR_github_repository_id: ${{ vars.TAILSCALE_SUBJECT_REPOSITORY_ID }}
           TF_VAR_github_enable_management: ${{ vars.INFRASTRUCTURE_GITHUB_MANAGEMENT_ENABLED }}
@@ -607,5 +630,6 @@ jobs:
           fi
           ./scripts/reconcile-infrastructure apply --phase '${{ inputs.phase }}' \
             --ct-operation '${{ inputs.ct_retirement }}' \
+            --tailscale-gateway-operation '${{ inputs.tailscale_gateway }}' \
             --proxmox-inventory inventory/infrastructure.yml \
             --arch-inventory inventory/production.yml "${migration_args[@]}"

--- a/docs/infrastructure-reconciliation.md
+++ b/docs/infrastructure-reconciliation.md
@@ -10,11 +10,28 @@ scripts/reconcile-infrastructure plan --phase steady
 scripts/reconcile-infrastructure apply --phase steady
 ```
 
-`bootstrap` and `adopt` are plan-only compatibility commands. Adoption deliberately stops after generating policy-inspected plans. Apply consumes saved plans rather than replanning, serializes OpenTofu operations with `-parallelism=1`, acquires the DynamoDB mutation lease, and requires post-apply no-op checks.
+`bootstrap` and `adopt` are plan-only compatibility commands. Adoption deliberately stops after generating policy-inspected plans. Apply consumes saved plans rather than replanning, serializes OpenTofu operations with `-parallelism=1`, acquires the DynamoDB mutation lease, and requires post-apply no-op checks. CT and Tailscale gateway lifecycle applies are main-only: GitHub requires exact `refs/heads/main` at `GITHUB_SHA`; local execution requires an attached `main` checkout at the existing `origin/main` commit. Plans and PR previews remain branch-safe.
 
 Plan credentials must be read-only. Apply credentials are loaded only after the plan boundary has passed. Never pass provider secrets as command arguments, artifacts, manifests, or logs. The CT confirmation is supplied only as the environment-scoped `PROXMOX_CT_DECOMMISSION_CONFIRMATION` GitHub secret. The reconciler verifies it without printing it, then exports it only as the sensitive, ephemeral `TF_VAR_decommission_confirmation` environment variable; it is never a CLI argument or manifest field and OpenTofu does not persist it in plan or state. OpenTofu independently validates its SHA-256 identity and fails planning when it is missing or invalid for an unprotected or retired durable stage, including steady operation `none`. The apply environment must supply it again so the independent hard gate remains active when consuming a saved plan.
 
-Special modes (`recovery`, network migration, CT retirement, and Omada qualification) have narrower policy allowlists and dedicated gates. They cannot be combined. A successful static plan is not proof that a provider can perform a live operation.
+Special modes (`recovery`, network migration, CT retirement, Tailscale gateway-policy lifecycle, and Omada qualification) have narrower policy allowlists and dedicated gates. They cannot be combined. A successful static plan is not proof that a provider can perform a live operation.
+
+## Tailscale gateway-policy lifecycle
+
+The durable `tailscale.gateway_policy_stage` is `active`, `detached`, or `retired`. `active` renders the historical complete policy. `detached` removes every legacy `tag:ci` use, route auto-approvers, and the two routed LAN grants while retaining the infra-router owner/admin grant for the live node. `retired` additionally removes that final owner and grant, and is allowed only after the CT contract stage is already `retired` and device absence has separate operator approval.
+
+PR comparison permits steady states, `active -> detached`, pre-CT-retirement `detached -> active` rollback, and `detached -> retired` only with an already retired CT. It rejects skips, transitions out of retired, and simultaneous CT/gateway transitions. The universally required Compose validation and infrastructure preview both run this comparison.
+
+After merging a stage transition to `main`, dispatch exactly the matching `tailscale_gateway` operation, or use:
+
+```sh
+scripts/reconcile-infrastructure plan --phase steady --tailscale-gateway-operation detach
+scripts/reconcile-infrastructure apply --phase steady --tailscale-gateway-operation detach
+```
+
+The saved-plan manifest binds operation, stage, the exact saved plan's canonical before/after policy SHA-256 values, and the live plan-time ETag. Planning fails unless the saved plan's canonical before SHA equals the live policy SHA captured with that ETag. Missing, duplicate-key, or otherwise noncanonicalizable before policy JSON fails closed. The dedicated plan policy permits only `terraform_data.tailscale_policy[0]` to update and requires all other roots, including all four federated identities, to be no-op. Apply re-extracts both policy identities from the hash-bound saved plan, validates through the single complete-policy endpoint, rechecks live SHA and ETag against that exact saved-plan before identity immediately before an `If-Match` POST, applies the exact state plan, proves live policy equals state, and finishes with a normal no-op. Exact-after partial recovery remains idempotent; unrelated live drift is never overwritten. Repeating a lifecycle operation is rejected at planning.
+
+Retirement additionally fails closed unless `TAILSCALE_GATEWAY_DEVICE_ABSENCE_APPROVED` is exactly `true` in both protected plan and apply environments. Set this temporary variable only after explicit device-deletion approval and read-only verification that the device is absent; it does not authorize device deletion. Remove it from both environments immediately after the retired no-op proof. Detach does not use this approval.
 
 ## CT 101 retirement lifecycle
 

--- a/docs/tailscale-adoption.md
+++ b/docs/tailscale-adoption.md
@@ -32,7 +32,7 @@ A failed partial apply retains its evidence and remote state. After correcting t
 
 The pinned Tailscale provider does not expose conditional policy updates. The repository therefore keeps the complete desired policy inside OpenTofu state while the guarded reconciler performs the policy API mutation from the saved plan using the captured `ETag`. The API update is validated first and uses `If-Match`; OpenTofu then records the exact same policy. Every steady plan compares live policy to the planned declaration, and every apply verifies live policy against state afterward.
 
-The existing `tag:infra-router` and legacy `tag:ci` policy entries remain represented during adoption. Their removal is a later reviewed change after CT 101 and every legacy CI dependency have been independently retired.
+The durable gateway-policy lifecycle is now `active -> detached -> retired`. The contract currently selects `detached`: the guarded detach operation removes the legacy `tag:ci` owner and all of its uses, route auto-approvers, and both routed LAN grants while retaining only the `tag:infra-router` owner/admin grant needed to manage the still-live node. This desired-state change is non-live until the exact saved-plan workflow is dispatched on `main`. Final `retired` policy is implemented but may be selected only after CT 101 is durably retired and device absence is separately approved.
 
 ## Recovery
 

--- a/docs/tailscale-bootstrap.md
+++ b/docs/tailscale-bootstrap.md
@@ -44,7 +44,7 @@ Completed prerequisites:
 The one-use, non-ephemeral `tag:docker-host` key was supplied only through the controller environment and a root-only
 temporary file. It was consumed during enrollment and removed immediately afterward.
 
-Historical conceptual policy fragment used during bootstrap—its `tag:ci` workload identity was retired, but the policy entries remain live and must be preserved unchanged during initial OpenTofu adoption:
+Historical conceptual policy fragment used during bootstrap—its `tag:ci` workload identity was retired. These entries were preserved through initial OpenTofu adoption; the contract now selects the guarded `detached` transition that removes them, but the live policy remains unchanged until that exact `main` operation is dispatched:
 
 ```json
 {
@@ -70,7 +70,7 @@ Historical conceptual policy fragment used during bootstrap—its `tag:ci` workl
 }
 ```
 
-The retained entries do not authorize a standing credential because no active workload identity can mint `tag:ci`. Remove them only in a separately reviewed post-adoption plan after the managed plan/apply identities and CT 101 independence are proven.
+The retained live entries do not authorize a standing credential because no active workload identity can mint `tag:ci`. Their reviewed removal is now represented by `tailscale.gateway_policy_stage: detached` and must occur only through the saved-plan gateway-policy operation.
 
 The current CI identities are `tag:ci-plan` and `tag:ci-apply` and use direct Docker connectivity as documented in
 [`github-actions-deploy.md`](./github-actions-deploy.md). The gateway, LAN SSH, and console remain independent recovery

--- a/infrastructure/contract/home-lab.yml
+++ b/infrastructure/contract/home-lab.yml
@@ -172,6 +172,7 @@ omada:
   provider_qualified: true
   required_consecutive_noop_plans: 3
 tailscale:
+  gateway_policy_stage: detached
   tags:
     arch: tag:docker-host
     proxmox: tag:proxmox

--- a/infrastructure/contract/schema.json
+++ b/infrastructure/contract/schema.json
@@ -103,9 +103,22 @@
     "tailscale": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["tags", "required_endpoints"],
+      "required": ["gateway_policy_stage", "tags", "required_endpoints"],
       "properties": {
-        "tags": { "type": "object", "additionalProperties": { "type": "string", "pattern": "^tag:" }, "minProperties": 4 },
+        "gateway_policy_stage": { "type": "string", "enum": ["active", "detached", "retired"] },
+        "tags": {
+          "type": "object",
+          "additionalProperties": { "type": "string", "pattern": "^tag:" },
+          "required": ["arch", "proxmox", "infra_router", "ci_legacy", "ci_plan", "ci_apply"],
+          "properties": {
+            "arch": { "type": "string", "pattern": "^tag:" },
+            "proxmox": { "type": "string", "pattern": "^tag:" },
+            "infra_router": { "const": "tag:infra-router" },
+            "ci_legacy": { "const": "tag:ci" },
+            "ci_plan": { "type": "string", "pattern": "^tag:" },
+            "ci_apply": { "type": "string", "pattern": "^tag:" }
+          }
+        },
         "required_endpoints": { "type": "array", "minItems": 4, "items": { "type": "string" }, "uniqueItems": true }
       }
     },

--- a/infrastructure/policy/inspect-plan.py
+++ b/infrastructure/policy/inspect-plan.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from copy import deepcopy
 import json
 from pathlib import Path
 import sys
@@ -50,6 +51,8 @@ def parse_args() -> argparse.Namespace:
             "recovery",
             "ct-unprotect",
             "ct-delete",
+            "ct-gateway-detach",
+            "ct-gateway-retire",
             "network-migration",
             "qualification",
         ),
@@ -79,6 +82,95 @@ def value_at_path(value: Any, path: tuple[str, ...]) -> Any:
         else:
             return None
     return current
+
+
+def contains_exact(value: Any, needle: str) -> bool:
+    if isinstance(value, dict):
+        return any(key == needle or contains_exact(entry, needle) for key, entry in value.items())
+    if isinstance(value, list):
+        return any(contains_exact(entry, needle) for entry in value)
+    return value == needle
+
+
+def unique_index(entries: Any, expected: Any, label: str) -> int:
+    if not isinstance(entries, list):
+        raise ValueError(f"{label} is not a list")
+    indexes = [index for index, entry in enumerate(entries) if entry == expected]
+    if len(indexes) != 1:
+        raise ValueError(f"{label} must occur exactly once")
+    return indexes[0]
+
+
+def detached_gateway_policy(active: Any) -> Any:
+    if not isinstance(active, dict):
+        raise ValueError("managed policy is not an object")
+    policy = deepcopy(active)
+    owners = policy.get("tagOwners")
+    if not isinstance(owners, dict) or owners.get("tag:ci") != ["autogroup:admin"]:
+        raise ValueError("legacy tag owner is missing or malformed")
+    del owners["tag:ci"]
+    expected_approvers = {
+        "routes": {
+            "192.168.0.100/32": ["tag:infra-router"],
+            "192.168.0.123/32": ["tag:infra-router"],
+        }
+    }
+    if policy.get("autoApprovers") != expected_approvers:
+        raise ValueError("gateway route auto-approvers are missing or malformed")
+    del policy["autoApprovers"]
+
+    grants = policy.get("grants")
+    for grant in (
+        {"src": ["autogroup:admin", "tag:ci"], "dst": ["192.168.0.123"], "ip": ["tcp:8006"]},
+        {"src": ["autogroup:admin", "tag:ci"], "dst": ["192.168.0.100"], "ip": ["tcp:22"]},
+    ):
+        del grants[unique_index(grants, grant, "routed LAN grant")]
+    docker_candidates = [
+        index for index, grant in enumerate(grants)
+        if isinstance(grant, dict) and grant.get("dst") == ["tag:docker-host"] and grant.get("ip") == ["tcp:22"]
+    ]
+    if len(docker_candidates) != 1:
+        raise ValueError("direct Docker grant must occur exactly once")
+    docker_grant = grants[docker_candidates[0]]
+    if not isinstance(docker_grant.get("src"), list) or docker_grant["src"].count("tag:ci") != 1:
+        raise ValueError("direct Docker grant has the wrong legacy-tag occurrence")
+    docker_grant["src"] = [source for source in docker_grant["src"] if source != "tag:ci"]
+
+    ssh = policy.get("ssh")
+    deploy_candidates = [
+        index for index, rule in enumerate(ssh)
+        if isinstance(rule, dict) and rule.get("dst") == ["tag:docker-host"] and rule.get("users") == ["ansible-deploy"]
+    ] if isinstance(ssh, list) else []
+    if len(deploy_candidates) != 1:
+        raise ValueError("ansible-deploy SSH rule must occur exactly once")
+    deploy_rule = ssh[deploy_candidates[0]]
+    if not isinstance(deploy_rule.get("src"), list) or deploy_rule["src"].count("tag:ci") != 1:
+        raise ValueError("ansible-deploy SSH rule has the wrong legacy-tag occurrence")
+    deploy_rule["src"] = [source for source in deploy_rule["src"] if source != "tag:ci"]
+    if contains_exact(policy, "tag:ci"):
+        raise ValueError("an unreviewed legacy tag occurrence remains")
+    return policy
+
+
+def retired_gateway_policy(detached: Any) -> Any:
+    policy = deepcopy(detached)
+    owners = policy.get("tagOwners") if isinstance(policy, dict) else None
+    if not isinstance(owners, dict) or owners.get("tag:infra-router") != ["autogroup:admin"]:
+        raise ValueError("infra-router tag owner is missing or malformed")
+    del owners["tag:infra-router"]
+    grant = {"src": ["autogroup:admin"], "dst": ["tag:infra-router"], "ip": ["*"]}
+    grants = policy.get("grants")
+    del grants[unique_index(grants, grant, "infra-router admin grant")]
+    if contains_exact(policy, "tag:infra-router"):
+        raise ValueError("an unreviewed infra-router tag occurrence remains")
+    return policy
+
+
+def policy_json(change: Any, side: str) -> Any:
+    value = (change.get(side) or {}).get("input", {}).get("policy_json")
+    if not isinstance(value, str):
+        raise ValueError(f"managed policy {side} JSON is missing")
+    return json.loads(value)
 
 
 def safe_protection_enable(before: Any, after: Any, path: tuple[str, ...]) -> bool:
@@ -197,6 +289,28 @@ def main() -> int:
                 failures.append(f"{address}: migration permits only the complete VM 100 host-device mapping transition")
             continue
 
+        if args.mode in {"ct-gateway-detach", "ct-gateway-retire"}:
+            try:
+                before_policy = policy_json(change, "before")
+                after_policy = policy_json(change, "after")
+                if args.mode == "ct-gateway-detach":
+                    expected_policy = detached_gateway_policy(before_policy)
+                    message = "gateway detach mode permits only the exact active-to-detached policy transformation"
+                else:
+                    expected_policy = retired_gateway_policy(before_policy)
+                    message = "gateway retire mode permits only the exact detached-to-retired policy transformation"
+                valid_change = (
+                    address == "terraform_data.tailscale_policy[0]"
+                    and actions == ["update"]
+                    and after_policy == expected_policy
+                )
+            except (AttributeError, json.JSONDecodeError, TypeError, ValueError):
+                valid_change = False
+                message = "gateway lifecycle policy is missing, malformed, or has the wrong source occurrences"
+            if not valid_change:
+                failures.append(f"{address}: {message}")
+            continue
+
         if args.mode in {"ct-unprotect", "ct-delete"}:
             target = "proxmox_virtual_environment_container.tailscale_gateway[0]"
             before = change.get("before") or {}
@@ -223,6 +337,17 @@ def main() -> int:
                 message = "CT delete mode permits only deletion of unprotected CT 101"
             if not valid_change:
                 failures.append(f"{address}: {message}")
+            continue
+
+        if address == "terraform_data.tailscale_policy[0]":
+            try:
+                before_policy = policy_json(change, "before")
+                after_policy = policy_json(change, "after")
+                rollback = before_policy == detached_gateway_policy(after_policy)
+            except (AttributeError, json.JSONDecodeError, TypeError, ValueError):
+                rollback = False
+            if not rollback:
+                failures.append(f"{address}: gateway-policy mutation requires its exact lifecycle operation")
             continue
 
         legacy_container = "proxmox_virtual_environment_container.tailscale_gateway[0]"
@@ -274,6 +399,11 @@ def main() -> int:
         and observed_addresses != MAPPING_ADDRESSES | {"proxmox_virtual_environment_vm.arch"}
     ):
         failures.append("hardware migration plan must contain all mappings and the VM transition")
+    if args.mode in {"ct-gateway-detach", "ct-gateway-retire"} and (
+        observed_actions != 1
+        or observed_addresses != {"terraform_data.tailscale_policy[0]"}
+    ):
+        failures.append("gateway lifecycle plan must contain exactly one complete policy update")
     if args.mode in {"ct-unprotect", "ct-delete"} and (
         observed_actions != 1
         or observed_addresses != {"proxmox_virtual_environment_container.tailscale_gateway[0]"}

--- a/infrastructure/policy/test-policy.sh
+++ b/infrastructure/policy/test-policy.sh
@@ -23,6 +23,8 @@ python3 "$policy" "$fixtures/protection-enable.json"
 python3 "$policy" "$fixtures/retired-branch-policy-delete.json"
 python3 "$policy" "$fixtures/qualification-create.json" --mode qualification
 python3 "$policy" "$fixtures/qualification-delete.json" --mode qualification
+python3 "$root/../../.github/scripts/test-tailscale-gateway-policy.py"
+python3 "$root/../../.github/scripts/test-reconcile-apply-source.py"
 
 for fixture in delete replace protection-disable ct-create ct-recreate; do
   expect_rejection "$fixture" normal

--- a/infrastructure/tofu/tailscale/main.tf
+++ b/infrastructure/tofu/tailscale/main.tf
@@ -43,7 +43,9 @@ locals {
   tags                  = local.contract.tailscale.tags
   github_subject_prefix = "repo:${local.contract.github.owner}@${var.github_owner_id}/${local.contract.github.repository}@${var.github_repository_id}"
 
-  policy = {
+  gateway_policy_stage = local.contract.tailscale.gateway_policy_stage
+
+  active_policy = {
     tagOwners = {
       (local.tags.arch)         = ["autogroup:admin"]
       (local.tags.proxmox)      = ["autogroup:admin"]
@@ -214,14 +216,53 @@ locals {
       },
     ]
   }
+
+  detached_policy = merge(
+    { for key, value in local.active_policy : key => value if key != "autoApprovers" },
+    {
+      tagOwners = {
+        for tag, owners in local.active_policy.tagOwners : tag => owners
+        if tag != local.tags.ci_legacy
+      }
+      grants = concat(
+        [local.active_policy.grants[0]],
+        [merge(local.active_policy.grants[3], {
+          src = [for source in local.active_policy.grants[3].src : source if source != local.tags.ci_legacy]
+        })],
+        slice(local.active_policy.grants, 4, length(local.active_policy.grants)),
+      )
+      ssh = concat(
+        [local.active_policy.ssh[0]],
+        [merge(local.active_policy.ssh[1], {
+          src = [for source in local.active_policy.ssh[1].src : source if source != local.tags.ci_legacy]
+        })],
+        slice(local.active_policy.ssh, 2, length(local.active_policy.ssh)),
+      )
+    },
+  )
+
+  retired_policy = merge(local.detached_policy, {
+    tagOwners = {
+      for tag, owners in local.detached_policy.tagOwners : tag => owners
+      if tag != local.tags.infra_router
+    }
+    grants = slice(local.detached_policy.grants, 1, length(local.detached_policy.grants))
+  })
+
+  policy_json_by_stage = {
+    active   = jsonencode(local.active_policy)
+    detached = jsonencode(local.detached_policy)
+    retired  = jsonencode(local.retired_policy)
+  }
+  policy_json = local.policy_json_by_stage[local.gateway_policy_stage]
 }
 
 resource "terraform_data" "tailscale_policy" {
   count = var.tailscale_enable_management ? 1 : 0
 
   input = {
-    policy_json   = jsonencode(local.policy)
-    policy_sha256 = sha256(jsonencode(local.policy))
+    policy_json   = local.policy_json
+    policy_sha256 = sha256(local.policy_json)
   }
 
   lifecycle {

--- a/scripts/bootstrap-tailscale-state
+++ b/scripts/bootstrap-tailscale-state
@@ -97,7 +97,11 @@ tailscale_policy_identity() {
     -o "$body"
   jq -cS -e . "$body" >"$canonical"
   etag=$(awk 'tolower($1) == "etag:" {gsub(/\r/, ""); sub(/^[^:]+:[[:space:]]*/, ""); print; exit}' "$headers")
-  [[ -n $etag ]]
+  [[ $etag =~ ^(W/)?\"[^\"[:cntrl:]]+\"$ ]] || {
+    echo "The Tailscale policy response is missing a valid ETag." >&2
+    rm -f "$headers" "$body" "$canonical"
+    return 1
+  }
   printf '%s\t%s\n' "$(sha256_file "$canonical")" "$etag"
   rm -f "$headers" "$body" "$canonical"
   unset access_token
@@ -121,6 +125,7 @@ apply_planned_policy() {
   chmod 0600 "$desired" "$response"
   tailscale_planned_policy "$plan" "$desired"
   desired_sha=$(sha256_file "$desired")
+  [[ $expected_sha =~ ^[0-9a-f]{64}$ && $expected_etag =~ ^(W/)?\"[^\"[:cntrl:]]+\"$ ]]
   IFS=$'\t' read -r current_sha current_etag < <(tailscale_policy_identity)
   if [[ $current_sha != "$desired_sha" ]]; then
     [[ $current_sha == "$expected_sha" && $current_etag == "$expected_etag" ]] || {
@@ -136,6 +141,12 @@ apply_planned_policy() {
       "https://api.tailscale.com/api/v2/tailnet/$TAILSCALE_TAILNET/acl/validate" \
       -o "$response"
     jq -e '((.errors // []) | length) == 0 and ((.warnings // []) | length) == 0' "$response" >/dev/null
+    IFS=$'\t' read -r current_sha current_etag < <(tailscale_policy_identity)
+    [[ $current_sha == "$expected_sha" && $current_etag == "$expected_etag" ]] || {
+      echo "The live Tailscale policy changed during validation; refusing POST." >&2
+      rm -f "$desired" "$response"
+      exit 1
+    }
     curl --fail --silent --show-error -X POST \
       -H "Authorization: Bearer $access_token" \
       -H 'Content-Type: application/json' \

--- a/scripts/reconcile-infrastructure
+++ b/scripts/reconcile-infrastructure
@@ -23,6 +23,8 @@ Options:
   --arch-bootstrap-inventory <path>   Temporary Arch recovery inventory
   --ct-operation <none|unprotect|delete>
                                       Select the qualified CT retirement policy (default: none)
+  --tailscale-gateway-operation <none|detach|retire>
+                                      Select the guarded gateway-policy lifecycle (default: none)
   --network-migration                 Permit only the reviewed hardware-mapping migration
 
 Required environment:
@@ -32,8 +34,9 @@ Required environment:
                                       Required outside protected CT steady state
 
 Apply additionally requires a clean checkout at the manifest commit and the
-DynamoDB mutation lease from the infrastructure contract. Recovery gates are
-supplied only through RECONCILE_ANSIBLE_EXTRA_VARS_FILE (an ignored root-only
+DynamoDB mutation lease from the infrastructure contract. CT and Tailscale
+gateway lifecycle applies additionally require the exact main commit. Recovery
+gates are supplied only through RECONCILE_ANSIBLE_EXTRA_VARS_FILE (an ignored root-only
 YAML file); they are never accepted as shell text. Proxmox host bootstrap must
 already have been run locally with console/LAN fallback before recovery apply.
 EOF
@@ -72,6 +75,7 @@ arch_inventory=inventory/production.yml
 arch_bootstrap_inventory=inventory/arch-recovery.yml
 recovery_backup_id=
 ct_retirement_operation=none
+tailscale_gateway_operation=none
 network_migration=false
 
 while (($#)); do
@@ -112,6 +116,11 @@ while (($#)); do
       ct_retirement_operation=$2
       shift 2
       ;;
+    --tailscale-gateway-operation)
+      (($# >= 2)) || usage
+      tailscale_gateway_operation=$2
+      shift 2
+      ;;
     --network-migration)
       network_migration=true
       shift
@@ -149,26 +158,43 @@ elif [[ -n $recovery_backup_id ]]; then
   usage
 fi
 case "$ct_retirement_operation" in none|unprotect|delete) ;; *) usage ;; esac
+case "$tailscale_gateway_operation" in none|detach|retire) ;; *) usage ;; esac
 unset TF_VAR_decommission_confirmation
 python3 .github/scripts/ct-retirement.py validate-operation \
   --contract infrastructure/contract/home-lab.yml \
   --operation "$ct_retirement_operation" || exit 64
+python3 .github/scripts/tailscale-gateway-policy.py validate-operation \
+  --contract infrastructure/contract/home-lab.yml \
+  --operation "$tailscale_gateway_operation" || exit 64
 if [[ -n ${PROXMOX_CT_DECOMMISSION_CONFIRMATION:-} ]]; then
   export TF_VAR_decommission_confirmation=$PROXMOX_CT_DECOMMISSION_CONFIRMATION
 fi
 ct_operation=false
 if [[ $ct_retirement_operation != none ]]; then ct_operation=true; fi
+tailscale_gateway_lifecycle=false
+if [[ $tailscale_gateway_operation != none ]]; then tailscale_gateway_lifecycle=true; fi
 if [[ $ct_operation == true && $phase != steady ]]; then
   echo "CT operations require steady phase." >&2
   exit 64
 fi
-if [[ $network_migration == true && ($phase != steady || $ct_operation == true) ]]; then
-  echo "Network migration requires steady phase and cannot be combined with CT operations." >&2
+if [[ $tailscale_gateway_lifecycle == true && $phase != steady ]]; then
+  echo "Tailscale gateway-policy operations require steady phase." >&2
   exit 64
 fi
-if [[ $omada_qualification_operation != none && ($network_migration == true || $ct_operation == true) ]]; then
+if [[ $network_migration == true && ($phase != steady || $ct_operation == true || $tailscale_gateway_lifecycle == true) ]]; then
+  echo "Network migration requires steady phase and cannot be combined with lifecycle operations." >&2
+  exit 64
+fi
+if [[ $ct_operation == true && $tailscale_gateway_lifecycle == true ]]; then
+  echo "CT and Tailscale gateway-policy lifecycle operations cannot be combined." >&2
+  exit 64
+fi
+if [[ $omada_qualification_operation != none && ($network_migration == true || $ct_operation == true || $tailscale_gateway_lifecycle == true) ]]; then
   echo "Omada qualification cannot be combined with another special operation." >&2
   exit 64
+fi
+if [[ $action == apply && ($ct_operation == true || $tailscale_gateway_lifecycle == true) ]]; then
+  python3 .github/scripts/reconcile-apply-source.py
 fi
 case "$plan_dir" in
   "$repo_root/.reconcile/"*) ;;
@@ -265,8 +291,8 @@ for root in "${roots[@]}"; do
 done
 roots=("${enabled_roots[@]}")
 unset enabled_roots
-if [[ $ct_operation == true && ${#roots[@]} -ne 6 ]]; then
-  echo "CT retirement requires every OpenTofu root to be enabled for no-op proof." >&2
+if [[ ($ct_operation == true || $tailscale_gateway_lifecycle == true) && ${#roots[@]} -ne 6 ]]; then
+  echo "Lifecycle operations require every OpenTofu root to be enabled for no-op proof." >&2
   exit 64
 fi
 sha256_file() {
@@ -317,9 +343,14 @@ tailscale_policy_identity() {
     -H 'Accept: application/json' \
     "https://api.tailscale.com/api/v2/tailnet/${TAILSCALE_TAILNET:--}/acl" \
     -o "$body"
-  jq -cS -e . "$body" >"$canonical"
+  python3 .github/scripts/tailscale-gateway-policy.py canonicalize-policy \
+    --policy "$body" >"$canonical"
   etag=$(awk 'tolower($1) == "etag:" {gsub(/\r/, ""); sub(/^[^:]+:[[:space:]]*/, ""); print; exit}' "$headers")
-  [[ -n $etag ]]
+  [[ $etag =~ ^(W/)?\"[^\"[:cntrl:]]+\"$ ]] || {
+    echo "The Tailscale policy response is missing a valid ETag." >&2
+    rm -f "$headers" "$body" "$canonical"
+    return 1
+  }
   identity="$(sha256_file "$canonical")"$'\t'"$etag"
   rm -f "$headers" "$body" "$canonical"
   unset access_token
@@ -327,30 +358,49 @@ tailscale_policy_identity() {
 }
 
 tailscale_planned_policy() {
-  local plan=$1 destination=$2
-  tofu -chdir=infrastructure/tofu/tailscale show -json "$plan" | jq -er '
-    .resource_changes[] |
-    select(.address == "terraform_data.tailscale_policy[0]") |
-    .change.after.input.policy_json |
-    fromjson
-  ' | jq -cS . >"$destination"
+  local plan=$1 side=$2 destination=$3
+  tofu -chdir=infrastructure/tofu/tailscale show -json "$plan" |
+    python3 .github/scripts/tailscale-gateway-policy.py extract-plan-policy \
+      --plan-json - --side "$side" >"$destination"
+}
+
+tailscale_verify_planned_policy_hashes() {
+  local plan=$1 expected_before_sha=$2 expected_after_sha=$3
+  local planned_before planned_after planned_before_sha planned_after_sha
+  planned_before=$(mktemp "${TMPDIR:-/tmp}/tailscale-planned-before.XXXXXX")
+  planned_after=$(mktemp "${TMPDIR:-/tmp}/tailscale-planned-after.XXXXXX")
+  chmod 0600 "$planned_before" "$planned_after"
+  tailscale_planned_policy "$plan" before "$planned_before"
+  tailscale_planned_policy "$plan" after "$planned_after"
+  planned_before_sha=$(sha256_file "$planned_before")
+  planned_after_sha=$(sha256_file "$planned_after")
+  rm -f "$planned_before" "$planned_after"
+  [[ $planned_before_sha == "$expected_before_sha" && $planned_after_sha == "$expected_after_sha" ]] || {
+    echo "The saved Tailscale plan policies differ from the manifest." >&2
+    return 1
+  }
 }
 
 tailscale_apply_planned_policy() {
-  local plan=$1 expected_sha=$2 expected_etag=$3
-  local desired current_sha current_etag desired_sha access_token response after_sha after_etag
+  local plan=$1 expected_before_sha=$2 expected_after_sha=$3 expected_etag=$4
+  local desired current_sha current_etag desired_sha access_token response after_sha after_etag disposition
   desired=$(mktemp "${TMPDIR:-/tmp}/tailscale-policy-desired.XXXXXX")
   response=$(mktemp "${TMPDIR:-/tmp}/tailscale-policy-response.XXXXXX")
   chmod 0600 "$desired" "$response"
-  tailscale_planned_policy "$plan" "$desired"
+  tailscale_verify_planned_policy_hashes "$plan" "$expected_before_sha" "$expected_after_sha"
+  tailscale_planned_policy "$plan" after "$desired"
   desired_sha=$(sha256_file "$desired")
+  [[ $expected_before_sha =~ ^[0-9a-f]{64}$ && $expected_after_sha =~ ^[0-9a-f]{64}$ ]]
+  [[ $expected_etag =~ ^(W/)?\"[^\"[:cntrl:]]+\"$ ]]
+  [[ $desired_sha == "$expected_after_sha" && $expected_before_sha != "$expected_after_sha" ]]
   IFS=$'\t' read -r current_sha current_etag < <(tailscale_policy_identity)
-  if [[ $current_sha != "$desired_sha" ]]; then
-    [[ $current_sha == "$expected_sha" && $current_etag == "$expected_etag" ]] || {
-      echo "The live Tailscale policy changed after planning; refusing the saved plan." >&2
-      rm -f "$desired" "$response"
-      exit 1
-    }
+  disposition=$(python3 .github/scripts/tailscale-gateway-policy.py apply-disposition \
+    --current-sha "$current_sha" \
+    --current-etag "$current_etag" \
+    --planned-before-sha "$expected_before_sha" \
+    --planned-after-sha "$expected_after_sha" \
+    --planned-etag "$expected_etag")
+  if [[ $disposition == post ]]; then
     access_token=$(tailscale_access_token)
     curl --fail --silent --show-error \
       -H "Authorization: Bearer $access_token" \
@@ -359,6 +409,18 @@ tailscale_apply_planned_policy() {
       "https://api.tailscale.com/api/v2/tailnet/${TAILSCALE_TAILNET:--}/acl/validate" \
       -o "$response"
     jq -e '((.errors // []) | length) == 0 and ((.warnings // []) | length) == 0' "$response" >/dev/null
+    IFS=$'\t' read -r current_sha current_etag < <(tailscale_policy_identity)
+    disposition=$(python3 .github/scripts/tailscale-gateway-policy.py apply-disposition \
+      --current-sha "$current_sha" \
+      --current-etag "$current_etag" \
+      --planned-before-sha "$expected_before_sha" \
+      --planned-after-sha "$expected_after_sha" \
+      --planned-etag "$expected_etag")
+    [[ $disposition == post ]] || {
+      echo "The live Tailscale policy changed during validation; refusing POST." >&2
+      rm -f "$desired" "$response"
+      exit 1
+    }
     curl --fail --silent --show-error -X POST \
       -H "Authorization: Bearer $access_token" \
       -H 'Content-Type: application/json' \
@@ -367,6 +429,10 @@ tailscale_apply_planned_policy() {
       "https://api.tailscale.com/api/v2/tailnet/${TAILSCALE_TAILNET:--}/acl" \
       -o "$response"
     unset access_token
+  else
+    # Recovery is idempotent only for a saved plan that proves a distinct before
+    # policy and whose live policy already equals that plan's exact after hash.
+    [[ $disposition == recovered && $expected_before_sha != "$desired_sha" ]]
   fi
   IFS=$'\t' read -r after_sha after_etag < <(tailscale_policy_identity)
   [[ $after_sha == "$desired_sha" && -n $after_etag ]]
@@ -429,6 +495,9 @@ policy_args() {
   if [[ $ct_operation == true && $root == proxmox-legacy ]]; then
     mode="ct-$ct_retirement_operation"
   fi
+  if [[ $tailscale_gateway_lifecycle == true && $root == tailscale ]]; then
+    mode="ct-gateway-$tailscale_gateway_operation"
+  fi
   if [[ $root == omada && $omada_qualification_operation != none ]]; then
     mode=qualification
   fi
@@ -471,15 +540,17 @@ plan_all() {
   ./scripts/validate-contract
   ./scripts/validate-provider-locks
 
-  local root plan exit_code tailscale_policy_sha256 tailscale_policy_etag tailscale_policy_changed desired_policy desired_policy_sha256
-  local compose_hash retirement_stage
+  local root plan exit_code tailscale_live_policy_sha256 tailscale_policy_before_sha256 tailscale_policy_after_sha256 tailscale_policy_etag tailscale_policy_changed
+  local planned_before_policy planned_after_policy compose_hash retirement_stage tailscale_gateway_policy_stage
   for root in "${roots[@]}"; do
     echo "Planning OpenTofu root: $root"
     backend_init "$root"
-    tailscale_policy_sha256=""
+    tailscale_live_policy_sha256=""
+    tailscale_policy_before_sha256=""
+    tailscale_policy_after_sha256=""
     tailscale_policy_etag=""
     if [[ $root == tailscale && ${TF_VAR_tailscale_enable_management:-false} == true ]]; then
-      IFS=$'\t' read -r tailscale_policy_sha256 tailscale_policy_etag < <(tailscale_policy_identity)
+      IFS=$'\t' read -r tailscale_live_policy_sha256 tailscale_policy_etag < <(tailscale_policy_identity)
     fi
     plan="$plan_dir/$root.tfplan"
     mapfile -d '' -t plan_args < <(root_plan_args "$root")
@@ -492,12 +563,20 @@ plan_all() {
     assert_plan_excludes_credentials "$plan"
     tailscale_policy_changed=false
     if [[ $root == tailscale && ${TF_VAR_tailscale_enable_management:-false} == true ]]; then
-      desired_policy=$(mktemp "${TMPDIR:-/tmp}/tailscale-planned-policy.XXXXXX")
-      chmod 0600 "$desired_policy"
-      tailscale_planned_policy "$plan" "$desired_policy"
-      desired_policy_sha256=$(sha256_file "$desired_policy")
-      [[ $desired_policy_sha256 == "$tailscale_policy_sha256" ]] || tailscale_policy_changed=true
-      rm -f "$desired_policy"
+      planned_before_policy=$(mktemp "${TMPDIR:-/tmp}/tailscale-planned-before.XXXXXX")
+      planned_after_policy=$(mktemp "${TMPDIR:-/tmp}/tailscale-planned-after.XXXXXX")
+      chmod 0600 "$planned_before_policy" "$planned_after_policy"
+      tailscale_planned_policy "$plan" before "$planned_before_policy"
+      tailscale_planned_policy "$plan" after "$planned_after_policy"
+      tailscale_policy_before_sha256=$(sha256_file "$planned_before_policy")
+      tailscale_policy_after_sha256=$(sha256_file "$planned_after_policy")
+      rm -f "$planned_before_policy" "$planned_after_policy"
+      if [[ $tailscale_gateway_lifecycle == true ]]; then
+        python3 .github/scripts/tailscale-gateway-policy.py validate-before-identity \
+          --planned-before-sha "$tailscale_policy_before_sha256" \
+          --live-before-sha "$tailscale_live_policy_sha256"
+      fi
+      [[ $tailscale_policy_after_sha256 == "$tailscale_policy_before_sha256" ]] || tailscale_policy_changed=true
     fi
 
     mapfile -d '' -t inspect_args < <(policy_args "$root")
@@ -506,11 +585,13 @@ plan_all() {
       --arg root "$root" \
       --arg file "$(basename "$plan")" \
       --arg sha256 "$(sha256_file "$plan")" \
-      --arg tailscale_policy_sha256 "$tailscale_policy_sha256" \
+      --arg tailscale_policy_before_sha256 "$tailscale_policy_before_sha256" \
+      --arg tailscale_policy_after_sha256 "$tailscale_policy_after_sha256" \
       --arg tailscale_policy_etag "$tailscale_policy_etag" \
       --argjson changed "$([[ $exit_code == 2 || $tailscale_policy_changed == true ]] && echo true || echo false)" \
       '{root: $root, file: $file, sha256: $sha256, changed: $changed,
-        tailscale_policy_sha256: $tailscale_policy_sha256,
+        tailscale_policy_before_sha256: $tailscale_policy_before_sha256,
+        tailscale_policy_after_sha256: $tailscale_policy_after_sha256,
         tailscale_policy_etag: $tailscale_policy_etag}' >>"$records"
   done
 
@@ -520,6 +601,15 @@ plan_all() {
       (map(select(.root != "proxmox-legacy" and .changed == true)) | length == 0)
     ' "$records" >/dev/null || {
       echo "CT operations require every other OpenTofu root to be a no-op." >&2
+      exit 1
+    }
+  fi
+  if [[ $tailscale_gateway_lifecycle == true ]]; then
+    jq -s -e '
+      (map(select(.root == "tailscale" and .changed == true)) | length == 1) and
+      (map(select(.root != "tailscale" and .changed == true)) | length == 0)
+    ' "$records" >/dev/null || {
+      echo "Tailscale gateway-policy operations require every other OpenTofu root to be a no-op." >&2
       exit 1
     }
   fi
@@ -535,16 +625,21 @@ plan_all() {
 
   compose_hash=$(python3 scripts/compose-artifact.py hash)
   retirement_stage=$(contract_value proxmox.legacy_container.retirement_stage)
+  tailscale_gateway_policy_stage=$(contract_value tailscale.gateway_policy_stage)
   jq -s \
     --arg commit "$commit" \
     --arg phase "$phase" \
     --arg ct_retirement_operation "$ct_retirement_operation" \
     --arg retirement_stage "$retirement_stage" \
+    --arg tailscale_gateway_operation "$tailscale_gateway_operation" \
+    --arg tailscale_gateway_policy_stage "$tailscale_gateway_policy_stage" \
     --argjson network_migration "$network_migration" \
     --arg backend_bucket "$backend_bucket" \
     --arg compose_hash "$compose_hash" \
     '{version: 2, commit: $commit, phase: $phase,
       ct_retirement_operation: $ct_retirement_operation, retirement_stage: $retirement_stage,
+      tailscale_gateway_operation: $tailscale_gateway_operation,
+      tailscale_gateway_policy_stage: $tailscale_gateway_policy_stage,
       network_migration: $network_migration, backend_bucket: $backend_bucket,
       compose_artifact_sha256: $compose_hash, plans: .}' \
     "$records" >"$plan_dir/manifest.json"
@@ -594,6 +689,10 @@ verify_manifest() {
     --manifest "$manifest" \
     --contract infrastructure/contract/home-lab.yml \
     --operation "$ct_retirement_operation"
+  python3 .github/scripts/tailscale-gateway-policy.py verify-manifest \
+    --manifest "$manifest" \
+    --contract infrastructure/contract/home-lab.yml \
+    --operation "$tailscale_gateway_operation"
   [[ $(jq -r .commit "$manifest") == "$commit" ]]
   [[ $(jq -r .phase "$manifest") == "$phase" ]]
   [[ $(jq -r .network_migration "$manifest") == "$network_migration" ]]
@@ -608,16 +707,31 @@ verify_manifest() {
     all(.plans[];
       .file == (.root + ".tfplan") and
       (.sha256 | test("^[0-9a-f]{64}$")) and
-      (.changed | type) == "boolean")
+      (.changed | type) == "boolean" and
+      if .root == "tailscale" then
+        (.tailscale_policy_before_sha256 | test("^[0-9a-f]{64}$")) and
+        (.tailscale_policy_after_sha256 | test("^[0-9a-f]{64}$")) and
+        (.tailscale_policy_etag | test("^(W/)?\\\"[^\\\"[:cntrl:]]+\\\"$"))
+      else
+        .tailscale_policy_before_sha256 == "" and
+        .tailscale_policy_after_sha256 == "" and
+        .tailscale_policy_etag == ""
+      end)
   ' "$manifest" >/dev/null || {
     echo "saved-plan manifest root set, paths, or hashes are invalid" >&2
     exit 66
   }
 
-  local root file expected
+  local root file expected expected_policy_before_sha256 expected_policy_after_sha256
   while IFS=$'\t' read -r root file expected; do
     [[ -f $plan_dir/$file ]]
     [[ $(sha256_file "$plan_dir/$file") == "$expected" ]]
+    if [[ $root == tailscale ]]; then
+      expected_policy_before_sha256=$(jq -r '.plans[] | select(.root == "tailscale") | .tailscale_policy_before_sha256' "$manifest")
+      expected_policy_after_sha256=$(jq -r '.plans[] | select(.root == "tailscale") | .tailscale_policy_after_sha256' "$manifest")
+      tailscale_verify_planned_policy_hashes "$plan_dir/$file" \
+        "$expected_policy_before_sha256" "$expected_policy_after_sha256"
+    fi
     backend_init "$root"
     mapfile -d '' -t inspect_args < <(policy_args "$root")
     TOFU_PLAN_CHDIR="infrastructure/tofu/$root" ./scripts/inspect-tofu-plan "$plan_dir/$file" "${inspect_args[@]}"
@@ -630,7 +744,7 @@ apply_root() {
     echo "Skipping disabled OpenTofu root: $root"
     return
   fi
-  local plan_file changed expected_policy_sha256 expected_policy_etag
+  local plan_file changed expected_policy_before_sha256 expected_policy_after_sha256 expected_policy_etag
   local old_proxmox=${PROXMOX_VE_API_TOKEN:-}
   local old_omada_username=${OMADA_USERNAME:-}
   local old_omada_password=${OMADA_PASSWORD:-}
@@ -675,10 +789,12 @@ apply_root() {
       ;;
   esac
   if [[ $root == tailscale ]]; then
-    expected_policy_sha256=$(jq -r --arg root "$root" '.plans[] | select(.root == $root) | .tailscale_policy_sha256' "$plan_dir/manifest.json")
+    expected_policy_before_sha256=$(jq -r --arg root "$root" '.plans[] | select(.root == $root) | .tailscale_policy_before_sha256' "$plan_dir/manifest.json")
+    expected_policy_after_sha256=$(jq -r --arg root "$root" '.plans[] | select(.root == $root) | .tailscale_policy_after_sha256' "$plan_dir/manifest.json")
     expected_policy_etag=$(jq -r --arg root "$root" '.plans[] | select(.root == $root) | .tailscale_policy_etag' "$plan_dir/manifest.json")
-    if [[ -n $expected_policy_sha256 && -n $expected_policy_etag ]]; then
-      tailscale_apply_planned_policy "$plan_dir/$plan_file" "$expected_policy_sha256" "$expected_policy_etag"
+    if [[ $expected_policy_before_sha256 != "$expected_policy_after_sha256" ]]; then
+      tailscale_apply_planned_policy "$plan_dir/$plan_file" \
+        "$expected_policy_before_sha256" "$expected_policy_after_sha256" "$expected_policy_etag"
     fi
   fi
   echo "Applying exact saved OpenTofu plan: $root"
@@ -916,6 +1032,15 @@ apply_ct_retirement() {
   verify_all
 }
 
+apply_tailscale_gateway_lifecycle() {
+  local root
+  for root in aws-foundation proxmox-legacy proxmox omada github; do
+    apply_root "$root"
+  done
+  apply_root tailscale
+  verify_all
+}
+
 apply_network_migration() {
   local root tag
   for root in aws-foundation proxmox-legacy omada tailscale github; do
@@ -950,6 +1075,10 @@ case "$action" in
     fi
     if [[ $ct_operation == true ]]; then
       apply_ct_retirement
+      exit 0
+    fi
+    if [[ $tailscale_gateway_lifecycle == true ]]; then
+      apply_tailscale_gateway_lifecycle
       exit 0
     fi
     if [[ $network_migration == true ]]; then

--- a/scripts/validate-contract
+++ b/scripts/validate-contract
@@ -33,6 +33,12 @@ for (let mirror = 0; mirror < 6; mirror += 1) {
 }
 if (contract.network.proxmox.ipv4 === contract.network.arch.ipv4) failures.push("host addresses must differ");
 if (contract.network.proxmox.mac === contract.network.arch.mac) failures.push("host MAC addresses must differ");
+if (contract.tailscale.gateway_policy_stage === "retired" && contract.proxmox.legacy_container.retirement_stage !== "retired") {
+  failures.push("retired Tailscale gateway policy requires retired CT 101");
+}
+if (contract.tailscale.gateway_policy_stage === "active" && contract.proxmox.legacy_container.retirement_stage === "retired") {
+  failures.push("active Tailscale gateway policy is forbidden after CT 101 retirement");
+}
 
 if (operational) {
   const required = [


### PR DESCRIPTION
## Summary
- add an active/detached/retired Tailscale gateway-policy lifecycle
- transition desired policy to detached, removing legacy CI and routed LAN access
- retain only direct administrator access to the still-running gateway node
- bind canonical policy before/after hashes and ETag to exact saved plans
- require all other roots no-op and main-only special applies

## Safety
- this PR does not mutate CT 101
- policy apply remains manual after merge through `tailscale_gateway=detach`
- OIDC identities, current direct Docker/Proxmox grants, tests, and SSH boundaries remain unchanged
- final infra-router removal remains separately gated by CT retirement, device deletion approval, and absence verification

## Validation
- real-root active/detached/retired policy rendering and lifecycle tests
- policy before-drift, manifest, ETag, operation-isolation, and main-only apply tests
- canonical repository validation, actionlint, ShellCheck, OpenTofu, Ansible, Compose, and independent reviews
