### PR TITLE
fix: initialize providers before plan inspection

### DIFF
--- a/.github/scripts/test-reconcile-manifest.py
+++ b/.github/scripts/test-reconcile-manifest.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Regression test for saved-plan verification with an empty provider cache."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPOSITORY = Path(__file__).resolve().parents[2]
+RECONCILER = REPOSITORY / "scripts/reconcile-infrastructure"
+ROOTS = ("aws-foundation", "proxmox-legacy", "proxmox", "tailscale")
+POLICY = '{"grants":[]}\n'
+
+
+def write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+class ManifestVerificationTests(unittest.TestCase):
+    def test_tailscale_plan_is_decoded_only_after_backend_init(self) -> None:
+        reconcile_root = REPOSITORY / ".reconcile"
+        reconcile_root.mkdir(exist_ok=True)
+        real_git = shutil.which("git")
+        self.assertIsNotNone(real_git)
+        commit = subprocess.run(
+            [real_git, "rev-parse", "HEAD"],
+            cwd=REPOSITORY,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        compose_hash = subprocess.run(
+            [sys.executable, "scripts/compose-artifact.py", "hash"],
+            cwd=REPOSITORY,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        policy_hash = hashlib.sha256(POLICY.encode()).hexdigest()
+
+        with tempfile.TemporaryDirectory(dir=reconcile_root) as directory:
+            temporary = Path(directory)
+            plan_dir = temporary / "plans"
+            provider_cache = temporary / "provider-cache"
+            binaries = temporary / "bin"
+            plan_dir.mkdir()
+            provider_cache.mkdir()
+            binaries.mkdir()
+            self.assertEqual(list(provider_cache.iterdir()), [])
+
+            plans = []
+            for root in ROOTS:
+                plan = plan_dir / f"{root}.tfplan"
+                plan.write_text(f"saved plan for {root}\n")
+                record = {
+                    "root": root,
+                    "file": plan.name,
+                    "sha256": hashlib.sha256(plan.read_bytes()).hexdigest(),
+                    "changed": False,
+                    "tailscale_policy_before_sha256": "",
+                    "tailscale_policy_after_sha256": "",
+                    "tailscale_policy_etag": "",
+                }
+                if root == "tailscale":
+                    record.update(
+                        tailscale_policy_before_sha256=policy_hash,
+                        tailscale_policy_after_sha256=policy_hash,
+                        tailscale_policy_etag='"test-etag"',
+                    )
+                plans.append(record)
+
+            manifest = {
+                "version": 2,
+                "commit": commit,
+                "phase": "steady",
+                "ct_retirement_operation": "none",
+                "retirement_stage": "protected",
+                "tailscale_gateway_operation": "none",
+                "tailscale_gateway_policy_stage": "active",
+                "network_migration": False,
+                "backend_bucket": "test-state-bucket",
+                "compose_artifact_sha256": compose_hash,
+                "plans": plans,
+            }
+            (plan_dir / "manifest.json").write_text(json.dumps(manifest))
+
+            log = temporary / "tofu.log"
+            write_executable(
+                binaries / "tofu",
+                """#!/usr/bin/env bash
+set -euo pipefail
+root=
+operation=
+for argument in "$@"; do
+  case "$argument" in
+    -chdir=*) root=${argument#-chdir=} ;;
+    init|show) operation=$argument ;;
+  esac
+done
+root=${root##*/}
+case "$operation" in
+  init)
+    printf 'init:%s\\n' "$root" >>"$TOFU_TEST_LOG"
+    : >"$TF_PLUGIN_CACHE_DIR/$root.ready"
+    ;;
+  show)
+    if [[ ! -f $TF_PLUGIN_CACHE_DIR/$root.ready ]]; then
+      echo "provider unavailable before init for $root" >&2
+      exit 72
+    fi
+    printf 'show:%s\\n' "$root" >>"$TOFU_TEST_LOG"
+    if [[ $root == tailscale ]]; then
+      cat <<'JSON'
+{"resource_changes":[{"address":"terraform_data.tailscale_policy[0]","type":"terraform_data","change":{"actions":["no-op"],"before":{"input":{"policy_json":"{\\"grants\\":[]}"}},"after":{"input":{"policy_json":"{\\"grants\\":[]}"}}}}]}
+JSON
+    else
+      printf '{"resource_changes":[]}\\n'
+    fi
+    ;;
+  *) echo "unexpected tofu command: $*" >&2; exit 73 ;;
+esac
+""",
+            )
+            write_executable(
+                binaries / "git",
+                f"""#!/usr/bin/env bash
+set -euo pipefail
+if [[ ${{1:-}} == rev-parse && ${{2:-}} == HEAD ]]; then
+  printf '%s\\n' "$MOCK_GIT_COMMIT"
+elif [[ ${{1:-}} == status ]]; then
+  exit 0
+else
+  exec {real_git} "$@"
+fi
+""",
+            )
+            write_executable(
+                binaries / "aws",
+                """#!/usr/bin/env bash
+echo 'test stopped before mutation lease acquisition' >&2
+exit 86
+""",
+            )
+            for command in ("ansible", "ansible-playbook", "curl"):
+                write_executable(binaries / command, "#!/usr/bin/env bash\nexit 0\n")
+
+            environment = {
+                **os.environ,
+                "PATH": f"{binaries}{os.pathsep}{os.environ['PATH']}",
+                "TF_BACKEND_BUCKET": "test-state-bucket",
+                "AWS_REGION": "us-east-1",
+                "TF_VAR_tailscale_enable_management": "true",
+                "TF_VAR_omada_enable_management": "false",
+                "TF_VAR_github_enable_management": "false",
+                "TF_PLUGIN_CACHE_DIR": str(provider_cache),
+                "TOFU_TEST_LOG": str(log),
+                "MOCK_GIT_COMMIT": commit,
+            }
+            result = subprocess.run(
+                [
+                    str(RECONCILER),
+                    "apply",
+                    "--phase",
+                    "steady",
+                    "--plan-dir",
+                    str(plan_dir),
+                ],
+                cwd=REPOSITORY,
+                env=environment,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+            self.assertEqual(result.returncode, 86, result.stderr)
+            self.assertIn("test stopped before mutation lease acquisition", result.stderr)
+            events = log.read_text().splitlines()
+            tailscale_init = events.index("init:tailscale")
+            tailscale_shows = [
+                index for index, event in enumerate(events) if event == "show:tailscale"
+            ]
+            self.assertGreaterEqual(len(tailscale_shows), 3)
+            self.assertTrue(all(tailscale_init < index for index in tailscale_shows))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/infrastructure-reconcile.yml
+++ b/.github/workflows/infrastructure-reconcile.yml
@@ -128,6 +128,7 @@ jobs:
           ./infrastructure/policy/test-policy.sh
           python .github/scripts/test-ct-retirement.py
           python .github/scripts/test-ct-compose-precheck.py
+          python .github/scripts/test-reconcile-manifest.py
           ./scripts/test-recovery-tools
           python -m py_compile scripts/*.py .github/scripts/*.py
           shellcheck scripts/reconcile-infrastructure scripts/bootstrap-aws-state scripts/bootstrap-tailscale-state \

--- a/docs/tailscale-adoption.md
+++ b/docs/tailscale-adoption.md
@@ -32,7 +32,7 @@ A failed partial apply retains its evidence and remote state. After correcting t
 
 The pinned Tailscale provider does not expose conditional policy updates. The repository therefore keeps the complete desired policy inside OpenTofu state while the guarded reconciler performs the policy API mutation from the saved plan using the captured `ETag`. The API update is validated first and uses `If-Match`; OpenTofu then records the exact same policy. Every steady plan compares live policy to the planned declaration, and every apply verifies live policy against state afterward.
 
-The durable gateway-policy lifecycle is now `active -> detached -> retired`. The contract currently selects `detached`: the guarded detach operation removes the legacy `tag:ci` owner and all of its uses, route auto-approvers, and both routed LAN grants while retaining only the `tag:infra-router` owner/admin grant needed to manage the still-live node. This desired-state change is non-live until the exact saved-plan workflow is dispatched on `main`. Final `retired` policy is implemented but may be selected only after CT 101 is durably retired and device absence is separately approved.
+The durable gateway-policy lifecycle is now `active -> detached -> retired`. The contract currently selects `active` while the manifest-initialization fix is qualified: a later reviewed transition to `detached` removes the legacy `tag:ci` owner and all of its uses, route auto-approvers, and both routed LAN grants while retaining only the `tag:infra-router` owner/admin grant needed to manage the still-live node. Final `retired` policy is implemented but may be selected only after CT 101 is durably retired and device absence is separately approved.
 
 ## Recovery
 

--- a/docs/tailscale-bootstrap.md
+++ b/docs/tailscale-bootstrap.md
@@ -70,7 +70,7 @@ Historical conceptual policy fragment used during bootstrap—its `tag:ci` workl
 }
 ```
 
-The retained live entries do not authorize a standing credential because no active workload identity can mint `tag:ci`. Their reviewed removal is now represented by `tailscale.gateway_policy_stage: detached` and must occur only through the saved-plan gateway-policy operation.
+The retained live entries do not authorize a standing credential because no active workload identity can mint `tag:ci`. Their reviewed removal is represented by the later `tailscale.gateway_policy_stage: detached` transition and must occur only through the saved-plan gateway-policy operation.
 
 The current CI identities are `tag:ci-plan` and `tag:ci-apply` and use direct Docker connectivity as documented in
 [`github-actions-deploy.md`](./github-actions-deploy.md). The gateway, LAN SSH, and console remain independent recovery

--- a/infrastructure/contract/home-lab.yml
+++ b/infrastructure/contract/home-lab.yml
@@ -172,7 +172,7 @@ omada:
   provider_qualified: true
   required_consecutive_noop_plans: 3
 tailscale:
-  gateway_policy_stage: detached
+  gateway_policy_stage: active
   tags:
     arch: tag:docker-host
     proxmox: tag:proxmox

--- a/scripts/reconcile-infrastructure
+++ b/scripts/reconcile-infrastructure
@@ -214,6 +214,7 @@ if [[ $action == validate ]]; then
   infrastructure/policy/test-policy.sh
   python3 .github/scripts/test-ct-retirement.py
   python3 .github/scripts/test-ct-compose-precheck.py
+  python3 .github/scripts/test-reconcile-manifest.py
   scripts/test-recovery-tools
   python3 -m py_compile scripts/*.py .github/scripts/*.py
   shellcheck scripts/reconcile-infrastructure scripts/bootstrap-aws-state scripts/bootstrap-tailscale-state \
@@ -726,13 +727,13 @@ verify_manifest() {
   while IFS=$'\t' read -r root file expected; do
     [[ -f $plan_dir/$file ]]
     [[ $(sha256_file "$plan_dir/$file") == "$expected" ]]
+    backend_init "$root"
     if [[ $root == tailscale ]]; then
       expected_policy_before_sha256=$(jq -r '.plans[] | select(.root == "tailscale") | .tailscale_policy_before_sha256' "$manifest")
       expected_policy_after_sha256=$(jq -r '.plans[] | select(.root == "tailscale") | .tailscale_policy_after_sha256' "$manifest")
       tailscale_verify_planned_policy_hashes "$plan_dir/$file" \
         "$expected_policy_before_sha256" "$expected_policy_after_sha256"
     fi
-    backend_init "$root"
     mapfile -d '' -t inspect_args < <(policy_args "$root")
     TOFU_PLAN_CHDIR="infrastructure/tofu/$root" ./scripts/inspect-tofu-plan "$plan_dir/$file" "${inspect_args[@]}"
   done < <(jq -r '.plans[] | [.root, .file, .sha256] | @tsv' "$manifest")


### PR DESCRIPTION
## Summary
- initialize each OpenTofu root before decoding its exact saved plan
- preserve manifest/hash/policy verification before lease acquisition or apply
- add an empty-provider-cache regression test

## Incident
The first guarded Tailscale detach apply stopped before mutation because plan inspection could not decode the Tailscale plan without the pinned provider package. No policy POST or OpenTofu apply occurred.

## Validation
- focused empty-cache manifest regression
- lifecycle and policy tests
- actionlint, ShellCheck, and shell syntax
- independent review
