### PR TITLE
feat: activate Tailscale route detachment

### DIFF
--- a/.github/scripts/test-reconcile-manifest.py
+++ b/.github/scripts/test-reconcile-manifest.py
@@ -46,6 +46,12 @@ class ManifestVerificationTests(unittest.TestCase):
             stdout=subprocess.PIPE,
         ).stdout.strip()
         policy_hash = hashlib.sha256(POLICY.encode()).hexdigest()
+        gateway_stage = next(
+            line.split(":", 1)[1].strip()
+            for line in (REPOSITORY / "infrastructure/contract/home-lab.yml").read_text().splitlines()
+            if line.strip().startswith("gateway_policy_stage:")
+        )
+        self.assertIn(gateway_stage, {"active", "detached", "retired"})
 
         with tempfile.TemporaryDirectory(dir=reconcile_root) as directory:
             temporary = Path(directory)
@@ -85,7 +91,7 @@ class ManifestVerificationTests(unittest.TestCase):
                 "ct_retirement_operation": "none",
                 "retirement_stage": "protected",
                 "tailscale_gateway_operation": "none",
-                "tailscale_gateway_policy_stage": "active",
+                "tailscale_gateway_policy_stage": gateway_stage,
                 "network_migration": False,
                 "backend_bucket": "test-state-bucket",
                 "compose_artifact_sha256": compose_hash,

--- a/docs/tailscale-adoption.md
+++ b/docs/tailscale-adoption.md
@@ -32,7 +32,7 @@ A failed partial apply retains its evidence and remote state. After correcting t
 
 The pinned Tailscale provider does not expose conditional policy updates. The repository therefore keeps the complete desired policy inside OpenTofu state while the guarded reconciler performs the policy API mutation from the saved plan using the captured `ETag`. The API update is validated first and uses `If-Match`; OpenTofu then records the exact same policy. Every steady plan compares live policy to the planned declaration, and every apply verifies live policy against state afterward.
 
-The durable gateway-policy lifecycle is now `active -> detached -> retired`. The contract currently selects `active` while the manifest-initialization fix is qualified: a later reviewed transition to `detached` removes the legacy `tag:ci` owner and all of its uses, route auto-approvers, and both routed LAN grants while retaining only the `tag:infra-router` owner/admin grant needed to manage the still-live node. Final `retired` policy is implemented but may be selected only after CT 101 is durably retired and device absence is separately approved.
+The durable gateway-policy lifecycle is now `active -> detached -> retired`. The contract currently selects `detached`: the guarded detach operation removes the legacy `tag:ci` owner and all of its uses, route auto-approvers, and both routed LAN grants while retaining only the `tag:infra-router` owner/admin grant needed to manage the still-live node. This desired-state change is non-live until the exact saved-plan workflow is dispatched on `main`. Final `retired` policy is implemented but may be selected only after CT 101 is durably retired and device absence is separately approved.
 
 ## Recovery
 

--- a/docs/tailscale-bootstrap.md
+++ b/docs/tailscale-bootstrap.md
@@ -70,7 +70,7 @@ Historical conceptual policy fragment used during bootstrap—its `tag:ci` workl
 }
 ```
 
-The retained live entries do not authorize a standing credential because no active workload identity can mint `tag:ci`. Their reviewed removal is represented by the later `tailscale.gateway_policy_stage: detached` transition and must occur only through the saved-plan gateway-policy operation.
+The retained live entries do not authorize a standing credential because no active workload identity can mint `tag:ci`. Their reviewed removal is now represented by `tailscale.gateway_policy_stage: detached` and must occur only through the saved-plan gateway-policy operation.
 
 The current CI identities are `tag:ci-plan` and `tag:ci-apply` and use direct Docker connectivity as documented in
 [`github-actions-deploy.md`](./github-actions-deploy.md). The gateway, LAN SSH, and console remain independent recovery

--- a/infrastructure/contract/home-lab.yml
+++ b/infrastructure/contract/home-lab.yml
@@ -172,7 +172,7 @@ omada:
   provider_qualified: true
   required_consecutive_noop_plans: 3
 tailscale:
-  gateway_policy_stage: active
+  gateway_policy_stage: detached
   tags:
     arch: tag:docker-host
     proxmox: tag:proxmox


### PR DESCRIPTION
## Summary
- transition the guarded gateway policy from `active` to `detached`
- remove legacy CI and routed LAN access while retaining direct administrator access to the live gateway node

## Expected plan
Exactly one update to the managed complete Tailscale policy. Every other root and every OIDC identity must be no-op. Apply remains a separate main-only manual dispatch.
