### PR TITLE
fix: support generated Proxmox CA

### DIFF
--- a/.github/scripts/proxmox-lxc-qualification.py
+++ b/.github/scripts/proxmox-lxc-qualification.py
@@ -473,6 +473,13 @@ def validate_state(state: Any, mode: str) -> None:
     )
 
 
+def proxmox_ssl_context() -> ssl.SSLContext:
+    context = ssl.create_default_context()
+    # Proxmox's generated CA predates the CA key-usage requirement enabled by
+    # Python/OpenSSL strict verification. Keep chain and hostname verification.
+    context.verify_flags &= ~ssl.VERIFY_X509_STRICT
+    return context
+
 def api_get(path: str, query: dict[str, str] | None = None) -> Any:
     endpoint = normalize_endpoint(os.environ.get("TF_VAR_proxmox_endpoint", ""))
     token = os.environ.get("PROXMOX_VE_API_TOKEN", "")
@@ -483,7 +490,7 @@ def api_get(path: str, query: dict[str, str] | None = None) -> Any:
         url = f"{url}?{parse.urlencode(query)}"
     api_request = request.Request(url, headers={"Authorization": f"PVEAPIToken={token}", "Accept": "application/json"})
     try:
-        with request.urlopen(api_request, timeout=20, context=ssl.create_default_context()) as response:
+        with request.urlopen(api_request, timeout=20, context=proxmox_ssl_context()) as response:
             document = json.load(response)
     except Exception as error:
         raise QualificationError("protected read-only Proxmox API validation failed") from error

--- a/.github/scripts/test-proxmox-lxc-qualification.py
+++ b/.github/scripts/test-proxmox-lxc-qualification.py
@@ -8,6 +8,7 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import ssl
 import tempfile
 import unittest
 from unittest import mock
@@ -343,6 +344,12 @@ class QualificationEvidenceTests(unittest.TestCase):
         for endpoint in ("http://proxmox/api2/json", "https://user@proxmox/api2/json", "https://proxmox", "https://proxmox/api?secret=x"):
             with self.subTest(endpoint=endpoint), self.assertRaises(qualification.QualificationError):
                 qualification.normalize_endpoint(endpoint)
+
+    def test_proxmox_ssl_context_preserves_chain_and_hostname_verification(self) -> None:
+        context = qualification.proxmox_ssl_context()
+        self.assertEqual(context.verify_mode, ssl.CERT_REQUIRED)
+        self.assertTrue(context.check_hostname)
+        self.assertFalse(context.verify_flags & ssl.VERIFY_X509_STRICT)
 
     def test_live_checks_bind_exact_config_volume_absence_and_template(self) -> None:
         for kind in ("vm", "subvol"):


### PR DESCRIPTION
## Summary
- retain strict certificate-chain and hostname verification for qualification API reads
- disable only OpenSSL's newer CA key-usage strictness for the generated Proxmox CA
- add an explicit regression test for retained TLS verification

## Evidence
- reproduced the pre-create API failure against the protected endpoint as `SSLCertVerificationError` code 92
- verified the compatibility context passes the exact read-only pre-create identity check
- 17 helper tests, 6 orchestration tests, workflow tests, policy fixtures, py_compile, and diff checks pass

No infrastructure was mutated by the failed create run.
