### PR TITLE
fix: count exact qualification lock

### DIFF
--- a/.github/scripts/test-qualify-proxmox-lxc.py
+++ b/.github/scripts/test-qualify-proxmox-lxc.py
@@ -137,7 +137,11 @@ class QualificationOrchestrationTests(unittest.TestCase):
                 #!/usr/bin/env bash
                 echo "aws $*" >>"$FAKE_LOG"
                 if [[ " $* " == *" s3api list-objects-v2 "* ]]; then
-                  echo "$FAKE_LOCK_COUNT"
+                  case "$FAKE_LOCK_COUNT" in
+                    0) echo '{"Contents":[]}' ;;
+                    1) echo '{"Contents":[{"Key":"home-lab/proxmox-lxc-qualification/tofu.tfstate.tflock"}]}' ;;
+                    *) echo '{"Contents":[{"Key":"home-lab/proxmox-lxc-qualification/tofu.tfstate.tflock"},{"Key":"home-lab/proxmox-lxc-qualification/tofu.tfstate.tflock.old"}]}' ;;
+                  esac
                 elif [[ " $* " == *" s3api get-object "* ]]; then
                   destination=${!#}
                   printf '{"ID":"%s","Operation":"%s","Info":"%s","Who":"%s","Version":"%s","Created":"%s","Path":"%s"}\n' "$FAKE_LOCK_ID" "$FAKE_LOCK_OPERATION" "$FAKE_LOCK_INFO" "$FAKE_LOCK_WHO" "$FAKE_LOCK_VERSION" "$FAKE_LOCK_CREATED" "$FAKE_LOCK_PATH" >"$destination"

--- a/scripts/qualify-proxmox-lxc
+++ b/scripts/qualify-proxmox-lxc
@@ -253,7 +253,18 @@ backend_lock_count() {
   aws s3api list-objects-v2 \
     --bucket "$TF_BACKEND_BUCKET" \
     --prefix "${backend_key}.tflock" \
-    --query 'KeyCount' --output text 2>"$work/backend-lock.log"
+    --output json >"$work/backend-list.json" 2>"$work/backend-lock.log" || return 1
+  BACKEND_LOCK_KEY="${backend_key}.tflock" python3 - "$work/backend-list.json" <<'PY'
+import json
+import os
+from pathlib import Path
+import sys
+value = json.loads(Path(sys.argv[1]).read_text())
+contents = value.get("Contents", [])
+if not isinstance(contents, list):
+    raise SystemExit(1)
+print(sum(isinstance(item, dict) and item.get("Key") == os.environ["BACKEND_LOCK_KEY"] for item in contents))
+PY
 }
 
 verify_backend_lock_absent() {


### PR DESCRIPTION
Count only the exact native OpenTofu lock key instead of every object sharing its prefix. JSON parsing fails closed. Ten orchestration tests, ShellCheck, and diff checks pass.