### PR TITLE
fix: normalize empty Proxmox defaults

### DIFF
--- a/.github/scripts/proxmox-lxc-qualification.py
+++ b/.github/scripts/proxmox-lxc-qualification.py
@@ -253,8 +253,10 @@ def validate_identity(
             raise QualificationError(f"qualification {name} capability is forbidden")
     if normalized.get("environment_variables") not in (None, {}) or normalized.get("tags") not in (None, []):
         raise QualificationError("qualification mappings or tags are forbidden")
-    if normalized.get("hook_script_file_id") is not None or normalized.get("pool_id") is not None:
+    if normalized.get("hook_script_file_id") not in (None, "") or normalized.get("pool_id") not in (None, ""):
         raise QualificationError("qualification hooks or pool mappings are forbidden")
+    normalized["hook_script_file_id"] = None
+    normalized["pool_id"] = None
     expected_timeouts = {
         "timeout_clone": 1800,
         "timeout_create": 1800,

--- a/.github/scripts/test-proxmox-lxc-qualification.py
+++ b/.github/scripts/test-proxmox-lxc-qualification.py
@@ -256,6 +256,11 @@ class QualificationEvidenceTests(unittest.TestCase):
         with self.env():
             qualification.validate_state(self.state(), "protected")
             qualification.validate_state(self.state(False), "unprotected")
+            provider_defaults = self.state()
+            provider_attributes = provider_defaults["resources"][0]["instances"][0]["attributes"]
+            provider_attributes["hook_script_file_id"] = ""
+            provider_attributes["pool_id"] = ""
+            qualification.validate_state(provider_defaults, "protected")
             qualification.validate_state({"resources": []}, "empty")
             with self.assertRaises(qualification.QualificationError):
                 qualification.validate_state(self.state(), "empty")


### PR DESCRIPTION
Normalize provider-emitted empty hook and pool IDs to null while continuing to reject every non-empty hook or pool mapping. Eighteen helper tests and diff checks pass.