### PR TITLE
fix: normalize empty LXC initialization

### DIFF
--- a/.github/scripts/proxmox-lxc-qualification.py
+++ b/.github/scripts/proxmox-lxc-qualification.py
@@ -301,6 +301,11 @@ def validate_identity(
         raise QualificationError("qualification root disk identity is invalid")
     initialization = singleton_block(normalized.get("initialization"), "initialization")
     exact_keys(initialization, {"dns", "entrypoint", "hostname", "ip_config", "user_account"}, "initialization")
+    for empty_block in ("dns", "ip_config", "user_account"):
+        if initialization.get(empty_block) is None:
+            initialization[empty_block] = []
+    if initialization.get("entrypoint") == "":
+        initialization["entrypoint"] = None
     if initialization != {
         "dns": [], "entrypoint": None, "hostname": MARKER, "ip_config": [], "user_account": []
     }:

--- a/.github/scripts/test-proxmox-lxc-qualification.py
+++ b/.github/scripts/test-proxmox-lxc-qualification.py
@@ -260,6 +260,11 @@ class QualificationEvidenceTests(unittest.TestCase):
             provider_attributes = provider_defaults["resources"][0]["instances"][0]["attributes"]
             provider_attributes["hook_script_file_id"] = ""
             provider_attributes["pool_id"] = ""
+            provider_initialization = provider_attributes["initialization"][0]
+            provider_initialization["dns"] = None
+            provider_initialization["entrypoint"] = ""
+            provider_initialization["ip_config"] = None
+            provider_initialization["user_account"] = None
             qualification.validate_state(provider_defaults, "protected")
             qualification.validate_state({"resources": []}, "empty")
             with self.assertRaises(qualification.QualificationError):


### PR DESCRIPTION
Normalize only provider-emitted empty initialization representations while preserving exact hostname and rejecting every non-empty DNS, network, user, or entrypoint capability. Eighteen helper tests and diff checks pass.